### PR TITLE
register NANPA prefix resource in ruby SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- /v3/nanpa_prefixes endpoints being added.
+
 ## [3.0.0]
 ### Breaking Changes
 - /v3/trunks being moved to /v3/voice_in_trunks.

--- a/lib/didww/client.rb
+++ b/lib/didww/client.rb
@@ -154,6 +154,10 @@ module DIDWW
         @@api_mode = arg
       end
 
+      def nanpa_prefixes
+        Resource::NanpaPrefix
+      end
+
       private
 
       def http_verbose?
@@ -203,6 +207,7 @@ module DIDWW
         require 'didww/resource/area'
         require 'didww/resource/voice_out_trunk'
         require 'didww/resource/voice_out_trunk_regenerate_credential'
+        require 'didww/resource/nanpa_prefix'
       end
 
     end

--- a/lib/didww/resource/nanpa_prefix.rb
+++ b/lib/didww/resource/nanpa_prefix.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DIDWW
+  module Resource
+    class NanpaPrefix < Base
+      has_one :country, class_name: Country
+      has_one :region, class_name: Region
+
+      property :npa, type: :string
+      # Type: String
+      # Description: NPA codes, or area codes consisting of three digits
+      property :nxx, type: :string
+      # Type: String
+      # Description: Refer to three-digit code
+      # that forms the second part of a 10-digit North American phone number
+    end
+  end
+end

--- a/spec/didww/resources/did_group_spec.rb
+++ b/spec/didww/resources/did_group_spec.rb
@@ -93,4 +93,21 @@ RSpec.describe DIDWW::Resource::DidGroup do
     end
   end
 
+  describe 'GET /did_group?filter[nanpa_prefix.id]={id}' do
+    context 'when DID group within NANPA prefix exists' do
+      let(:nanpa_prefix_id) { SecureRandom.uuid }
+
+      before do
+        stub_didww_request(:get, "/did_groups?filter[nanpa_prefix.id]=#{nanpa_prefix_id}").to_return(
+          status: 200,
+          body: api_fixture('did_groups/get/sample_1/200'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'returns a collection of DidGroups' do
+        expect(client.did_groups.where('nanpa_prefix.id': nanpa_prefix_id).all).to be_a_list_of(DIDWW::Resource::DidGroup)
+      end
+    end
+  end
 end

--- a/spec/didww/resources/nanpa_prefix_spec.rb
+++ b/spec/didww/resources/nanpa_prefix_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe DIDWW::Resource::NanpaPrefix do
+  let(:client) { DIDWW::Client }
+
+  describe 'GET /nanpa_prefixes/{id}' do
+    context 'when NANPA prefix exists' do
+      let(:id) { 'a1ad26e5-1413-4edc-862b-1075378b6034' }
+
+      before do
+        stub_didww_request(:get, "/nanpa_prefixes/#{id}").to_return(
+          status: 200,
+          body: api_fixture('nanpa_prefixes/id/get/sample_1/200'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'returns a instance of NANPA prefix' do
+        expect(client.nanpa_prefixes.load(id: id)).to be_instance_of(DIDWW::Resource::NanpaPrefix)
+      end
+    end
+  end
+
+  describe 'GET /nanpa_prefixes' do
+    context 'when valid request' do
+      before do
+        stub_didww_request(:get, '/nanpa_prefixes').to_return(
+          status: 200,
+          body: api_fixture('nanpa_prefixes/get/sample_1/200'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'returns a collection of NANPA prefixes' do
+        expect(client.nanpa_prefixes.all).to be_a_list_of(DIDWW::Resource::NanpaPrefix)
+      end
+    end
+
+    context 'when include by country' do
+      before do
+        stub_didww_request(:get, '/nanpa_prefixes?include=country').to_return(
+          status: 200,
+          body: api_fixture('nanpa_prefixes/get/include/country'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'returns a instance of Country' do
+        expect(client.nanpa_prefixes.includes(:country).all.first.country).to be_instance_of(DIDWW::Resource::Country)
+      end
+    end
+
+    context 'when include by region' do
+      before do
+        stub_didww_request(:get, '/nanpa_prefixes?include=region').to_return(
+          status: 200,
+          body: api_fixture('nanpa_prefixes/get/include/region'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'returns a instance of Region' do
+        expect(client.nanpa_prefixes.includes(:region).all.first.region).to be_instance_of(DIDWW::Resource::Region)
+      end
+    end
+
+    context 'when include by all relationships' do
+      before do
+        stub_didww_request(:get, '/nanpa_prefixes?include=region,country').to_return(
+          status: 200,
+          body: api_fixture('nanpa_prefixes/get/include/region_country'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'returns a instance of Region' do
+        expect(client.nanpa_prefixes.includes(:region, :country).all.first.region).to be_instance_of(DIDWW::Resource::Region)
+      end
+
+      it 'returns a instance of Country' do
+        expect(client.nanpa_prefixes.includes(:region, :country).all.first.country).to be_instance_of(DIDWW::Resource::Country)
+      end
+    end
+  end
+end

--- a/spec/fixtures/nanpa_prefixes/get/include/country.json
+++ b/spec/fixtures/nanpa_prefixes/get/include/country.json
@@ -1,0 +1,126 @@
+{
+  "data": [
+    {
+      "id": "70e51033-106c-4e4f-9985-05f7424941df",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "416",
+        "nxx": "200"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/country"
+          },
+          "data": {
+            "type": "countries",
+            "id": "efa8d53b-d7b3-404d-8bc9-1e8075ceff4c"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/region"
+          }
+        }
+      }
+    },
+    {
+      "id": "54943e12-88e9-4df9-be54-a72926c251dd",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "200"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/country"
+          },
+          "data": {
+            "type": "countries",
+            "id": "2b941b50-aedb-43fe-b420-31257889a61b"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/region"
+          }
+        }
+      }
+    },
+    {
+      "id": "d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "920"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/country"
+          },
+          "data": {
+            "type": "countries",
+            "id": "2b941b50-aedb-43fe-b420-31257889a61b"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/region"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "efa8d53b-d7b3-404d-8bc9-1e8075ceff4c",
+      "type": "countries",
+      "attributes": {
+        "name": "Canada",
+        "prefix": "1",
+        "iso": "CA"
+      },
+      "relationships": {
+        "regions": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/countries/efa8d53b-d7b3-404d-8bc9-1e8075ceff4c/relationships/regions",
+            "related": "https://sandbox-api.didww.com/v3/countries/efa8d53b-d7b3-404d-8bc9-1e8075ceff4c/regions"
+          }
+        }
+      }
+    },
+    {
+      "id": "2b941b50-aedb-43fe-b420-31257889a61b",
+      "type": "countries",
+      "attributes": {
+        "name": "United States",
+        "prefix": "1",
+        "iso": "US"
+      },
+      "relationships": {
+        "regions": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/countries/2b941b50-aedb-43fe-b420-31257889a61b/relationships/regions",
+            "related": "https://sandbox-api.didww.com/v3/countries/2b941b50-aedb-43fe-b420-31257889a61b/regions"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_records": 3,
+    "api_version": "2022-05-09"
+  },
+  "links": {
+    "first": "https://sandbox-api.didww.com/v3/nanpa_prefixes?include=country&page%5Bnumber%5D=1&page%5Bsize%5D=50",
+    "last": "https://sandbox-api.didww.com/v3/nanpa_prefixes?include=country&page%5Bnumber%5D=1&page%5Bsize%5D=50"
+  }
+}

--- a/spec/fixtures/nanpa_prefixes/get/include/region.json
+++ b/spec/fixtures/nanpa_prefixes/get/include/region.json
@@ -1,0 +1,124 @@
+{
+  "data": [
+    {
+      "id": "70e51033-106c-4e4f-9985-05f7424941df",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "416",
+        "nxx": "200"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/country"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/region"
+          },
+          "data": {
+            "type": "regions",
+            "id": "8dc21c02-6918-48d2-bd4f-cf5aa88637f9"
+          }
+        }
+      }
+    },
+    {
+      "id": "54943e12-88e9-4df9-be54-a72926c251dd",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "200"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/country"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/region"
+          },
+          "data": {
+            "type": "regions",
+            "id": "99f6d445-65b2-4c61-842a-86cdc841ebb9"
+          }
+        }
+      }
+    },
+    {
+      "id": "d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "920"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/country"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/region"
+          },
+          "data": {
+            "type": "regions",
+            "id": "99f6d445-65b2-4c61-842a-86cdc841ebb9"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "8dc21c02-6918-48d2-bd4f-cf5aa88637f9",
+      "type": "regions",
+      "attributes": {
+        "name": "Manitoba",
+        "iso": "CA-MB"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/regions/8dc21c02-6918-48d2-bd4f-cf5aa88637f9/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/regions/8dc21c02-6918-48d2-bd4f-cf5aa88637f9/country"
+          }
+        }
+      }
+    },
+    {
+      "id": "99f6d445-65b2-4c61-842a-86cdc841ebb9",
+      "type": "regions",
+      "attributes": {
+        "name": "South Carolina",
+        "iso": "US-SC"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/regions/99f6d445-65b2-4c61-842a-86cdc841ebb9/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/regions/99f6d445-65b2-4c61-842a-86cdc841ebb9/country"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_records": 3,
+    "api_version": "2022-05-09"
+  },
+  "links": {
+    "first": "https://sandbox-api.didww.com/v3/nanpa_prefixes?include=region&page%5Bnumber%5D=1&page%5Bsize%5D=50",
+    "last": "https://sandbox-api.didww.com/v3/nanpa_prefixes?include=region&page%5Bnumber%5D=1&page%5Bsize%5D=50"
+  }
+}

--- a/spec/fixtures/nanpa_prefixes/get/include/region_country.json
+++ b/spec/fixtures/nanpa_prefixes/get/include/region_country.json
@@ -1,0 +1,170 @@
+{
+  "data": [
+    {
+      "id": "70e51033-106c-4e4f-9985-05f7424941df",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "416",
+        "nxx": "200"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/country"
+          },
+          "data": {
+            "type": "countries",
+            "id": "efa8d53b-d7b3-404d-8bc9-1e8075ceff4c"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/70e51033-106c-4e4f-9985-05f7424941df/region"
+          },
+          "data": {
+            "type": "regions",
+            "id": "8dc21c02-6918-48d2-bd4f-cf5aa88637f9"
+          }
+        }
+      }
+    },
+    {
+      "id": "54943e12-88e9-4df9-be54-a72926c251dd",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "200"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/country"
+          },
+          "data": {
+            "type": "countries",
+            "id": "2b941b50-aedb-43fe-b420-31257889a61b"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/region"
+          },
+          "data": {
+            "type": "regions",
+            "id": "99f6d445-65b2-4c61-842a-86cdc841ebb9"
+          }
+        }
+      }
+    },
+    {
+      "id": "d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "920"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/country"
+          },
+          "data": {
+            "type": "countries",
+            "id": "2b941b50-aedb-43fe-b420-31257889a61b"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/region"
+          },
+          "data": {
+            "type": "regions",
+            "id": "99f6d445-65b2-4c61-842a-86cdc841ebb9"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "efa8d53b-d7b3-404d-8bc9-1e8075ceff4c",
+      "type": "countries",
+      "attributes": {
+        "name": "Canada",
+        "prefix": "1",
+        "iso": "CA"
+      },
+      "relationships": {
+        "regions": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/countries/efa8d53b-d7b3-404d-8bc9-1e8075ceff4c/relationships/regions",
+            "related": "https://sandbox-api.didww.com/v3/countries/efa8d53b-d7b3-404d-8bc9-1e8075ceff4c/regions"
+          }
+        }
+      }
+    },
+    {
+      "id": "2b941b50-aedb-43fe-b420-31257889a61b",
+      "type": "countries",
+      "attributes": {
+        "name": "United States",
+        "prefix": "1",
+        "iso": "US"
+      },
+      "relationships": {
+        "regions": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/countries/2b941b50-aedb-43fe-b420-31257889a61b/relationships/regions",
+            "related": "https://sandbox-api.didww.com/v3/countries/2b941b50-aedb-43fe-b420-31257889a61b/regions"
+          }
+        }
+      }
+    },
+    {
+      "id": "8dc21c02-6918-48d2-bd4f-cf5aa88637f9",
+      "type": "regions",
+      "attributes": {
+        "name": "Manitoba",
+        "iso": "CA-MB"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/regions/8dc21c02-6918-48d2-bd4f-cf5aa88637f9/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/regions/8dc21c02-6918-48d2-bd4f-cf5aa88637f9/country"
+          }
+        }
+      }
+    },
+    {
+      "id": "99f6d445-65b2-4c61-842a-86cdc841ebb9",
+      "type": "regions",
+      "attributes": {
+        "name": "South Carolina",
+        "iso": "US-SC"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/regions/99f6d445-65b2-4c61-842a-86cdc841ebb9/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/regions/99f6d445-65b2-4c61-842a-86cdc841ebb9/country"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_records": 3,
+    "api_version": "2022-05-09"
+  },
+  "links": {
+    "first": "https://sandbox-api.didww.com/v3/nanpa_prefixes?include=region%2Ccountry&page%5Bnumber%5D=1&page%5Bsize%5D=50",
+    "last": "https://sandbox-api.didww.com/v3/nanpa_prefixes?include=region%2Ccountry&page%5Bnumber%5D=1&page%5Bsize%5D=50"
+  }
+}

--- a/spec/fixtures/nanpa_prefixes/get/sample_1/200.json
+++ b/spec/fixtures/nanpa_prefixes/get/sample_1/200.json
@@ -1,0 +1,56 @@
+{
+  "data": [
+    {
+      "id": "54943e12-88e9-4df9-be54-a72926c251dd",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "200"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/country"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/54943e12-88e9-4df9-be54-a72926c251dd/region"
+          }
+        }
+      }
+    },
+    {
+      "id": "d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "920"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/country"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/d557ec68-fdb9-41bd-adc1-ebcc2ecd8f98/region"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_records": 2,
+    "api_version": "2022-05-09"
+  },
+  "links": {
+    "first": "https://sandbox-api.didww.com/v3/nanpa_prefixes?page%5Bnumber%5D=1&page%5Bsize%5D=50",
+    "last": "https://sandbox-api.didww.com/v3/nanpa_prefixes?page%5Bnumber%5D=1&page%5Bsize%5D=50"
+  }
+}

--- a/spec/fixtures/nanpa_prefixes/id/get/sample_1/200.json
+++ b/spec/fixtures/nanpa_prefixes/id/get/sample_1/200.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "id": "a1ad26e5-1413-4edc-862b-1075378b6034",
+    "type": "nanpa_prefixes",
+    "attributes": {
+      "npa": "864",
+      "nxx": "920"
+    },
+    "relationships": {
+      "country": {
+        "links": {
+          "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/a1ad26e5-1413-4edc-862b-1075378b6034/relationships/country",
+          "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/a1ad26e5-1413-4edc-862b-1075378b6034/country"
+        }
+      },
+      "region": {
+        "links": {
+          "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/a1ad26e5-1413-4edc-862b-1075378b6034/relationships/region",
+          "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/a1ad26e5-1413-4edc-862b-1075378b6034/region"
+        }
+      }
+    }
+  },
+  "meta": {
+    "api_version": "2022-05-09"
+  }
+}


### PR DESCRIPTION
usage examples:

```
require 'didww'

c = DIDWW::Client.configure do |config|
  config.api_key  = 'api_key'
end

united_states = c.countries.where(iso: 'US').first
sc_region = c.regions.where(name: 'South Carolina').first

npa_nxx_prefixes = c.nanpa_prefixes.where('region.id': sc_region.id, 'country.id': united_states.id).all

did_groups = c.did_groups.where('nanpa_prefix.id': npa_nxx_prefixes.first.id).all
```
closes #28 