### PR TITLE
removed deprecated cop named: Lint/UselessElseWithoutRescue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -303,10 +303,6 @@ Lint/UselessAssignment:
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: false
 
-# Checks for useless `else` in `begin..end` without `rescue`.
-Lint/UselessElseWithoutRescue:
-  Enabled: false
-
 # Checks for useless setter call to a local variable.
 Lint/UselessSetterCall:
   Enabled: false


### PR DESCRIPTION
then cop removed in this [commit](https://github.com/rubocop/rubocop/pull/10577/commits/6d0b336e8e17f96ec07cde54a0975ae39db1874a) 

because

Ruby 2.6 does not support `begin` ... `else` syntax.
So `Lint/UselessElseWithoutRescue ` can't work because it causes a parsing error.