### PR TITLE
Create a DID order with a specific NPA/NXX prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - /v3/nanpa_prefixes endpoints being added.
 
+### Changes
+- /v3/orders endpoints being updated. Added nanpa_prefix_id attribute for DID order item.
+
 ## [3.0.0]
 ### Breaking Changes
 - /v3/trunks being moved to /v3/voice_in_trunks.

--- a/lib/didww/complex_objects/did_order_item.rb
+++ b/lib/didww/complex_objects/did_order_item.rb
@@ -8,6 +8,7 @@ module DIDWW
       property :did_reservation_id,   type: :string
       property :sku_id,               type: :string
       property :billing_cycles_count, type: :string
+      property :nanpa_prefix_id,      type: :string
 
       # returned
       property :setup_price,          type: :decimal

--- a/spec/fixtures/orders/post/sample_2/201.json
+++ b/spec/fixtures/orders/post/sample_2/201.json
@@ -7,6 +7,7 @@
       "status": "Pending",
       "created_at": "2017-06-25T14:56:31.513Z",
       "description": "DID",
+      "reference": "DVH-349963",
       "items": [
         {
           "type": "did_order_items",


### PR DESCRIPTION
### Create a DID order with a specific NPA/NXX prefix
added new attribute for DIDWW::ComplexObject::DidOrderItem complex_object
to create DID order within specific nanpa_prefix

example:
```
did_order_item = DIDWW::ComplexObject::DidOrderItem.new(sku_id: sku_id, nanpa_prefix_id: nanpa_prefix_id)
order = client.orders.new(allow_back_ordering: false, items: [did_order_item])
order.save

irb(main):001:0> order.status
#=> "Pending"
```