### PR TITLE
Filter available_dids resource by nanpa_prefix

### DIFF
--- a/lib/didww/resource/available_did.rb
+++ b/lib/didww/resource/available_did.rb
@@ -3,6 +3,7 @@ module DIDWW
   module Resource
     class AvailableDid < Base
       has_one :did_group
+      has_one :nanpa_prefix
 
       property :number, type: :string
       # Type: String

--- a/spec/didww/resources/available_did_spec.rb
+++ b/spec/didww/resources/available_did_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe DIDWW::Resource::AvailableDid do
       end
     end
 
+    context 'with include nanpa_prefix' do
+      subject do
+        client.available_dids.includes(:nanpa_prefix).find(id)
+      end
+
+      let!(:mock_get_record_request) do
+        stub_didww_request(:get, "/available_dids/#{id}?include=nanpa_prefix").to_return(
+          status: 200,
+          body: api_fixture('available_dids/get/include_nanpa_prefix/200'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'should fetch NanpaPrefix resource' do
+        subject
+        expect(available_did.nanpa_prefix).to be_kind_of(DIDWW::Resource::NanpaPrefix)
+        expect(available_did.nanpa_prefix).to have_attributes npa: be_kind_of(String), nxx: be_kind_of(String)
+      end
+
+      it 'request should be performed properly' do
+        subject
+        expect(mock_get_record_request).to have_been_requested.at_least_once
+      end
+    end
+
     context 'with include did_group.stock_keeping_units' do
       subject do
         client.available_dids.includes(:'did_group.stock_keeping_units').find(id)
@@ -119,6 +144,32 @@ RSpec.describe DIDWW::Resource::AvailableDid do
       end
     end
 
+    describe 'GET /available_dids?filter[nanpa_prefix.id]={id}' do
+      subject { client.available_dids.where('nanpa_prefix.id': nanpa_prefix_id).all }
+
+      let(:nanpa_prefix_id) { SecureRandom.uuid }
+
+      context 'when Available DID within NANPA prefix is exists' do
+        let!(:mock_get_available_dids_request) do
+          stub_didww_request(:get, "/available_dids?filter[nanpa_prefix.id]=#{nanpa_prefix_id}").to_return(
+            status: 200,
+            body: api_fixture('available_dids/get/sample_1/200'),
+            headers: json_api_headers
+          )
+        end
+
+        it 'returns a collection of Available Dids' do
+          expect(subject).to be_a_list_of(DIDWW::Resource::AvailableDid)
+          expect(subject.count).to eq 2
+          expect(subject.sample.type).to eq described_class.type
+        end
+
+        it 'request should be performed properly' do
+          subject
+          expect(mock_get_available_dids_request).to have_been_requested.at_least_once
+        end
+      end
+    end
   end
 
 end

--- a/spec/fixtures/available_dids/get/include_nanpa_prefix/200.json
+++ b/spec/fixtures/available_dids/get/include_nanpa_prefix/200.json
@@ -1,0 +1,82 @@
+{
+  "data": [
+    {
+      "id": "73d5ac10-95cc-413d-9c75-66d5fa6b3461",
+      "type": "available_dids",
+      "attributes": {
+        "number": "1864920445"
+      },
+      "relationships": {
+        "did_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/available_dids/73d5ac10-95cc-413d-9c75-66d5fa6b3461/relationships/did_group",
+            "related": "https://sandbox-api.didww.com/v3/available_dids/73d5ac10-95cc-413d-9c75-66d5fa6b3461/did_group"
+          }
+        },
+        "nanpa_prefix": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/available_dids/73d5ac10-95cc-413d-9c75-66d5fa6b3461/relationships/nanpa_prefix",
+            "related": "https://sandbox-api.didww.com/v3/available_dids/73d5ac10-95cc-413d-9c75-66d5fa6b3461/nanpa_prefix"
+          },
+          "data": {
+            "type": "nanpa_prefixes",
+            "id": "e4c36c29-e0e2-4d4f-bd0f-341613e14bc3"
+          }
+        }
+      }
+    },
+    {
+      "id": "34056b89-5b6e-4261-9dc5-948b474f2043",
+      "type": "available_dids",
+      "attributes": {
+        "number": "1864920444"
+      },
+      "relationships": {
+        "did_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/available_dids/34056b89-5b6e-4261-9dc5-948b474f2043/relationships/did_group",
+            "related": "https://sandbox-api.didww.com/v3/available_dids/34056b89-5b6e-4261-9dc5-948b474f2043/did_group"
+          }
+        },
+        "nanpa_prefix": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/available_dids/34056b89-5b6e-4261-9dc5-948b474f2043/relationships/nanpa_prefix",
+            "related": "https://sandbox-api.didww.com/v3/available_dids/34056b89-5b6e-4261-9dc5-948b474f2043/nanpa_prefix"
+          },
+          "data": {
+            "type": "nanpa_prefixes",
+            "id": "e4c36c29-e0e2-4d4f-bd0f-341613e14bc3"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "e4c36c29-e0e2-4d4f-bd0f-341613e14bc3",
+      "type": "nanpa_prefixes",
+      "attributes": {
+        "npa": "864",
+        "nxx": "920"
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/e4c36c29-e0e2-4d4f-bd0f-341613e14bc3/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/e4c36c29-e0e2-4d4f-bd0f-341613e14bc3/country"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/nanpa_prefixes/e4c36c29-e0e2-4d4f-bd0f-341613e14bc3/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/nanpa_prefixes/e4c36c29-e0e2-4d4f-bd0f-341613e14bc3/region"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total_count": 3,
+    "api_version": "2022-05-09"
+  }
+}


### PR DESCRIPTION
Filter available DIDs by nanpa_prefix
request example
```
GET /available_dids?filter[nanpa_prefix.id]={id}
```
Using Ruby SDK:
```
client.available_dids.where('nanpa_prefix.id': nanpa_prefix_id).all
client.available_dids.includes(:did_group).find(id)
```