### PR TITLE
Removed local_prefix attribute from DidGroup in favour of the new NanpaPrefix entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Breaking Changes
+- /v3/did_groups removed `local_prefix` attribute
 ### Added
 - /v3/nanpa_prefixes endpoints being added.
 

--- a/lib/didww/resource/did_group.rb
+++ b/lib/didww/resource/did_group.rb
@@ -23,10 +23,6 @@ module DIDWW
       # Type: String
       # Description: DID Group prefix (city or area calling code)
 
-      property :local_prefix, type: :string
-      # Type: String
-      # Description: DID Group local prefix
-
       property :features, type: :complex_object  # TODO implement array of strings?
       # Type: Array of strings
       # Description: Features available for the DID Group, including voice, sms and t38. A DID Group may have multiple features.

--- a/spec/didww/resources/did_group_spec.rb
+++ b/spec/didww/resources/did_group_spec.rb
@@ -37,9 +37,6 @@ RSpec.describe DIDWW::Resource::DidGroup do
       it 'the DidGroup has "prefix", type: String' do
         expect(did_group.prefix).to be_kind_of(String)
       end
-      it 'the DidGroup has "local_prefix", type: String' do
-        expect(did_group.local_prefix).to be_kind_of(String)
-      end
       it 'the DidGroup has "is_metered", type: Boolean' do
         expect(did_group.is_metered).to be_in([true, false])
       end

--- a/spec/fixtures/did_groups/get/sample_1/200.json
+++ b/spec/fixtures/did_groups/get/sample_1/200.json
@@ -8,7 +8,6 @@
       },
       "attributes": {
         "prefix": "77",
-        "local_prefix": "",
         "features": [
           "voice",
           "sms"
@@ -62,7 +61,6 @@
       },
       "attributes": {
         "prefix": "3",
-        "local_prefix": "",
         "features": [
           "voice"
         ],

--- a/spec/fixtures/did_groups/get/sample_2/200.json
+++ b/spec/fixtures/did_groups/get/sample_2/200.json
@@ -8,7 +8,6 @@
       },
       "attributes": {
         "prefix": "77",
-        "local_prefix": "",
         "features": [
           "voice",
           "sms"
@@ -82,7 +81,6 @@
       },
       "attributes": {
         "prefix": "3",
-        "local_prefix": "",
         "features": [
           "voice"
         ],

--- a/spec/fixtures/did_groups/id/get/sample_1/200.json
+++ b/spec/fixtures/did_groups/id/get/sample_1/200.json
@@ -7,7 +7,6 @@
     },
     "attributes": {
       "prefix": "77",
-      "local_prefix": "",
       "features": [
         "voice",
         "sms"

--- a/spec/fixtures/did_groups/id/get/sample_2/200.json
+++ b/spec/fixtures/did_groups/id/get/sample_2/200.json
@@ -7,7 +7,6 @@
     },
     "attributes": {
       "prefix": "77",
-      "local_prefix": "",
       "features": [
         "voice",
         "sms"


### PR DESCRIPTION
Remove local_prefix from the DidGroup resource in favour of the new NanpaPrefix resource
    
    Removed deprecated attribute from DIDWW::Resource::DidGroup resource.