### PR TITLE
Filtering DID group by NPA NXX

### DIFF
--- a/spec/didww/resources/did_group_spec.rb
+++ b/spec/didww/resources/did_group_spec.rb
@@ -110,4 +110,31 @@ RSpec.describe DIDWW::Resource::DidGroup do
       end
     end
   end
+
+  describe 'GET /did_group?filter[nanpa_prefix.npanxx]={npanxx}' do
+    subject { client.did_groups.where('nanpa_prefix.npanxx': npa_nxx).all }
+
+    let(:npa_nxx) { %w[864 920].join }
+
+    context 'when DID group within 864920 NANPA prefix exists' do
+      let!(:mock_get_record_request) do
+        stub_didww_request(:get, "/did_groups?filter[nanpa_prefix.npanxx]=#{npa_nxx}").to_return(
+          status: 200,
+          body: api_fixture('did_groups/get/filter_by_npa_nxx/200'),
+          headers: json_api_headers
+        )
+      end
+
+      it 'returns a collection of DidGroups' do
+        expect(subject).to be_a_list_of(DIDWW::Resource::DidGroup)
+        expect(subject.count).to eq 1
+        expect(subject.sample.type).to eq described_class.type
+      end
+
+      it 'request should be performed properly' do
+        subject
+        expect(mock_get_record_request).to have_been_requested.at_least_once
+      end
+    end
+  end
 end

--- a/spec/fixtures/did_groups/get/filter_by_npa_nxx/200.json
+++ b/spec/fixtures/did_groups/get/filter_by_npa_nxx/200.json
@@ -1,0 +1,69 @@
+{
+  "data": [
+    {
+      "id": "f69196cc-2b00-4310-a550-3c433c350d35",
+      "type": "did_groups",
+      "attributes": {
+        "prefix": "864",
+        "features": [
+          "voice_in"
+        ],
+        "is_metered": false,
+        "area_name": "Anderson",
+        "allow_additional_channels": true
+      },
+      "relationships": {
+        "country": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/relationships/country",
+            "related": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/country"
+          }
+        },
+        "city": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/relationships/city",
+            "related": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/city"
+          }
+        },
+        "did_group_type": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/relationships/did_group_type",
+            "related": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/did_group_type"
+          }
+        },
+        "region": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/relationships/region",
+            "related": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/region"
+          }
+        },
+        "stock_keeping_units": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/relationships/stock_keeping_units",
+            "related": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/stock_keeping_units"
+          }
+        },
+        "requirement": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/relationships/requirement",
+            "related": "https://sandbox-api.didww.com/v3/did_groups/f69196cc-2b00-4310-a550-3c433c350d35/requirement"
+          }
+        }
+      },
+      "meta": {
+        "available_dids_enabled": true,
+        "needs_registration": false,
+        "is_available": true,
+        "total_count": 2
+      }
+    }
+  ],
+  "meta": {
+    "total_records": 1,
+    "api_version": "2022-05-09"
+  },
+  "links": {
+    "first": "https://sandbox-api.didww.com/v3/did_groups?filter%5Bnanpa_prefix.npanxx%5D=864920&page%5Bnumber%5D=1&page%5Bsize%5D=50",
+    "last": "https://sandbox-api.didww.com/v3/did_groups?filter%5Bnanpa_prefix.npanxx%5D=864920&page%5Bnumber%5D=1&page%5Bsize%5D=50"
+  }
+}


### PR DESCRIPTION
### Perform filtering by the combination of two fields NPA and NXX

example:

```
npa_nxx = ['864', '920'].join
client.did_groups.where('nanpa_prefix.npanxx': npa_nxx).all
```