### PR TITLE
Improve CI & fix bug in test spec/didww/client_spec.rb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,5 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Run tests
         run: |
-          gem install bundler -v 2.2.7
           bundle install
           bundle exec rake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       RAILS_VERSION: ${{ matrix.rails }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
-        rails: [ '~> 5.0', '~> 6.0' ]
+        ruby: [ '2.7' ]
+        rails: [ '~> 6.0' ]
     name: Tests with Ruby ${{ matrix.ruby }} Activesupport ${{ matrix.rails }}
     env:
       RAILS_VERSION: ${{ matrix.rails }}

--- a/spec/didww/client_spec.rb
+++ b/spec/didww/client_spec.rb
@@ -2,11 +2,14 @@
 RSpec.describe DIDWW::Client do
   let(:api_key) { 'f02c46006f6fa4746cd019abffb0a949' }
   let(:sandbox_uri) { 'https://sandbox-api.didww.com/v3/' }
-  let(:prod_uri) { 'https://sandbox-api.didww.com/v3/' }
+  let(:prod_uri) { 'https://api.didww.com/v3/' }
 
-  before(:each) do
-    DIDWW.send(:remove_const, :Client)
-    load 'didww/client.rb'
+  after do
+    # restore DIDWW client configuration
+    DIDWW::Client.configure do |client|
+      client.api_key  = nil
+      client.api_mode = :sandbox
+    end
   end
 
   it 'configures' do

--- a/spec/didww/complex_objects/base_spec.rb
+++ b/spec/didww/complex_objects/base_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DIDWW::ComplexObject::Base do
     end
 
     it 'uses type casting for defined properties' do
-      expect( test_instance.known ).to be_kind_of(Fixnum)
+      expect( test_instance.known ).to be_kind_of(Integer)
     end
   end
 end


### PR DESCRIPTION
This pull request addresses several issues and improvements in the codebase. Here's a summary of the changes made in each commit:

1. Commit: Ensure the use of "sandbox" as the default api_mode in the test environment.
Description: This commit fixes a failure that occurred when executing a chain of test suites due to a modification of the default api_mode from "sandbox" to "production" in the "spec/didww/client_spec.rb" specification file. To resolve this, I suggest reloading the DIDWW::Client constant after the specific test in "spec/didww/client_spec.rb".

1. Commit: Use Integer instead of Fixnum.
Description: In Ruby, the Fixnum class has been deprecated since Ruby 2.4 and removed in Ruby 3. Instead, the Integer class should be used, which encompasses both Fixnums and Bignums. This commit updates the codebase to use the Integer class.

1. Commit: Use ruby/setup-ruby@v1 instead of deprecated actions/setup-ruby@v1.
Description: The actions/setup-ruby@v1 action has been deprecated. This commit replaces it with the updated ruby/setup-ruby@v1 action to ensure compatibility and proper Ruby setup.

1. Commit: remove support ruby version 2.5, 2.6 and activesupport with 5.0.
Description: Remove support for Ruby versions 2.5 and 2.6, as well as ActiveSupport "~> 5.0", since they are no longer maintained.

closes #36 