### PR TITLE
Add new features for DID Group resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Breaking Changes
+- removed DIDWW::Resource::DidGroup::FEATURE_VOICE => in favor DIDWW::Resource::DidGroup::FEATURE_VOICE_IN and DIDWW::Resource::DidGroup::FEATURE_VOICE_OUT [#42](https://github.com/didww/didww-v3-ruby/pull/42)
+- removed DIDWW::Resource::DidGroup::FEATURE_SMS in favor of DIDWW::Resource::DidGroup::FEATURE_SMS_IN and DIDWW::Resource::DidGroup::FEATURE_SMS_OUT [#42](https://github.com/didww/didww-v3-ruby/pull/42)
+
 ## [4.0.0]
 ### Breaking Changes
 - /v3/did_groups removed `local_prefix` attribute

--- a/lib/didww/resource/did_group.rb
+++ b/lib/didww/resource/did_group.rb
@@ -3,14 +3,19 @@ module DIDWW
   module Resource
     class DidGroup < Base
       # Possible values for did_group.features array
-      FEATURE_VOICE    = 'voice'                           .freeze
-      FEATURE_T38      = 't38'                             .freeze
-      FEATURE_SMS      = 'sms'                             .freeze
+      FEATURE_VOICE_IN = 'voice_in'
+      FEATURE_VOICE_OUT = 'voice_out'
+      FEATURE_T38 = 't38'
+      FEATURE_IN_SMS = 'sms_in'
+      FEATURE_OUT_SMS = 'sms_out'
+
       FEATURES = {
-                   FEATURE_VOICE => 'Voice'                           .freeze,
-                   FEATURE_T38   => 'T.38 Fax'                        .freeze,
-                   FEATURE_SMS   => 'SMS'                             .freeze
-                 }.freeze
+        FEATURE_VOICE_IN => 'Voice IN',
+        FEATURE_VOICE_OUT => 'Voice OUT',
+        FEATURE_T38 => 'T.38 Fax',
+        FEATURE_IN_SMS => 'SMS IN',
+        FEATURE_OUT_SMS => 'SMS OUT'
+      }.freeze
 
       has_one :country, class: Country
       has_one :city,    class: City

--- a/spec/didww/resources/did_group_spec.rb
+++ b/spec/didww/resources/did_group_spec.rb
@@ -3,14 +3,22 @@ RSpec.describe DIDWW::Resource::DidGroup do
   let (:client) { DIDWW::Client }
 
   it 'has FEATURES constant' do
-    expect(described_class::FEATURES).to include('t38', 'voice', 'sms')
+    expect(DIDWW::Resource::DidGroup::FEATURES).to match(
+      hash_including(
+        'sms_in' => 'SMS IN',
+        'sms_out' => 'SMS OUT',
+        't38' => 'T.38 Fax',
+        'voice_in' => 'Voice IN',
+        'voice_out' => 'Voice OUT',
+      )
+    )
   end
 
   describe '#features_human' do
     it 'humanizes features array attribute' do
       expect(subject.features_human).to eq([])
-      subject.features = ['t38', 'voice']
-      expect(subject.features_human).to eq(['T.38 Fax', 'Voice'])
+      subject.features = %w[t38 voice_in]
+      expect(subject.features_human).to eq(['T.38 Fax', 'Voice IN'])
     end
   end
 

--- a/spec/fixtures/available_dids/get/sample_2/200.json
+++ b/spec/fixtures/available_dids/get/sample_2/200.json
@@ -53,8 +53,8 @@
         "prefix": "77",
         "local_prefix": "",
         "features": [
-          "voice",
-          "sms"
+          "voice_in",
+          "sms_in"
         ],
         "is_metered": false,
         "area_name": "National",

--- a/spec/fixtures/available_dids/id/get/sample_2/200.json
+++ b/spec/fixtures/available_dids/id/get/sample_2/200.json
@@ -29,8 +29,8 @@
         "prefix": "77",
         "local_prefix": "",
         "features": [
-          "voice",
-          "sms"
+          "voice_in",
+          "sms_in"
         ],
         "is_metered": false,
         "area_name": "National",

--- a/spec/fixtures/available_dids/id/get/sample_3/200.json
+++ b/spec/fixtures/available_dids/id/get/sample_3/200.json
@@ -24,7 +24,7 @@
         "allow_additional_channels": true,
         "area_name": "Washington",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "local_prefix": "",

--- a/spec/fixtures/did_groups/get/sample_1/200.json
+++ b/spec/fixtures/did_groups/get/sample_1/200.json
@@ -9,8 +9,8 @@
       "attributes": {
         "prefix": "77",
         "features": [
-          "voice",
-          "sms"
+          "voice_in",
+          "sms_in"
         ],
         "is_metered": false,
         "area_name": "National",
@@ -62,7 +62,7 @@
       "attributes": {
         "prefix": "3",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "area_name": "Tel Aviv",

--- a/spec/fixtures/did_groups/get/sample_2/200.json
+++ b/spec/fixtures/did_groups/get/sample_2/200.json
@@ -9,8 +9,8 @@
       "attributes": {
         "prefix": "77",
         "features": [
-          "voice",
-          "sms"
+          "voice_in",
+          "sms_in"
         ],
         "is_metered": false,
         "area_name": "National",
@@ -82,7 +82,7 @@
       "attributes": {
         "prefix": "3",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "area_name": "Tel Aviv",

--- a/spec/fixtures/did_groups/id/get/sample_1/200.json
+++ b/spec/fixtures/did_groups/id/get/sample_1/200.json
@@ -8,8 +8,8 @@
     "attributes": {
       "prefix": "77",
       "features": [
-        "voice",
-        "sms"
+        "voice_in",
+        "sms_in"
       ],
       "is_metered": false,
       "area_name": "National",

--- a/spec/fixtures/did_groups/id/get/sample_2/200.json
+++ b/spec/fixtures/did_groups/id/get/sample_2/200.json
@@ -8,8 +8,8 @@
     "attributes": {
       "prefix": "77",
       "features": [
-        "voice",
-        "sms"
+        "voice_in",
+        "sms_in"
       ],
       "is_metered": false,
       "area_name": "National",

--- a/spec/fixtures/did_reservations/id/get/sample_3/200.json
+++ b/spec/fixtures/did_reservations/id/get/sample_3/200.json
@@ -45,7 +45,7 @@
         "allow_additional_channels": true,
         "area_name": "Washington",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "local_prefix": "",

--- a/spec/fixtures/did_reservations/id/get/sample_4/200.json
+++ b/spec/fixtures/did_reservations/id/get/sample_4/200.json
@@ -45,7 +45,7 @@
         "allow_additional_channels": true,
         "area_name": "Washington",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "local_prefix": "",

--- a/spec/fixtures/dids/get/sample_2/200.json
+++ b/spec/fixtures/dids/get/sample_2/200.json
@@ -130,7 +130,7 @@
         "prefix": "720",
         "local_prefix": "",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "area_name": "National",
@@ -179,7 +179,7 @@
         "prefix": "11",
         "local_prefix": "",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "area_name": "Mobile",

--- a/spec/fixtures/dids/id/get/sample_2/200.json
+++ b/spec/fixtures/dids/id/get/sample_2/200.json
@@ -69,7 +69,7 @@
         "prefix": "721",
         "local_prefix": "",
         "features": [
-          "voice"
+          "voice_in"
         ],
         "is_metered": false,
         "area_name": "National",


### PR DESCRIPTION
According to the documentation, we have this list of features
```
 “voice_in”, “voice_out”, “t38”, “sms_in”, “sms_out”. 
```
https://doc.didww.com/api3/2022-05-10/coverage-resources/did-group/get-did-groups.html

So we have to update the `DIDWW::Resource::DidGroup::FEATURES` feature list to be up-to-date.

closes #33