### PR TITLE
Fix post-rollout: requirement_validations 201 (not 204) + Order.canceled? rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed (BREAKING)
+- Rename `Order.cancelled?` to `canceled?` and `Order::STATUS_CANCELLED` to `STATUS_CANCELED` to match the wire-format (`status: "canceled"`).
+
 ## [5.3.0]
 ### Added
 - `DIDWW::Client.customize_connection` to allow customizing the Faraday connection (e.g. proxy, timeouts, custom middleware).

--- a/examples/emergency_calling_services.rb
+++ b/examples/emergency_calling_services.rb
@@ -52,7 +52,7 @@ puts "Found #{active.size} active services"
 # if (svc = services.find { |s| s.status == 'active' })
 #   puts "\nCancelling service #{svc.id}..."
 #   if svc.destroy
-#     puts 'Service cancelled'
+#     puts 'Service canceled'
 #   else
 #     puts "Error: #{svc.errors.full_messages}"
 #   end

--- a/examples/orders.rb
+++ b/examples/orders.rb
@@ -60,7 +60,7 @@ if order.save
   # Cancel order (delete it)
   puts "\n=== Cancelling Order ==="
   if order.destroy
-    puts 'Order cancelled'
+    puts 'Order canceled'
   else
     puts "Error cancelling order: #{order.errors.full_messages}"
   end

--- a/lib/didww/resource/did.rb
+++ b/lib/didww/resource/did.rb
@@ -19,7 +19,7 @@ module DIDWW
 
       property :blocked, type: :boolean
       # Type: Boolean
-      # Description: Identifier for a blocked DID. Blocked DIDs are numbers that have expired, have been cancelled or have been suspended by DIDWW.
+      # Description: Identifier for a blocked DID. Blocked DIDs are numbers that have expired, have been canceled or have been suspended by DIDWW.
 
       property :awaiting_registration, type: :boolean
       # Type: Boolean

--- a/lib/didww/resource/order.rb
+++ b/lib/didww/resource/order.rb
@@ -12,13 +12,13 @@ module DIDWW
       include HasStatusHelpers
 
       # Possible values for order.status
-      STATUS_PENDING      = 'pending'
-      STATUS_COMPLETED    = 'completed'
-      STATUS_CANCELLED    = 'canceled'
+      STATUS_PENDING   = 'pending'
+      STATUS_COMPLETED = 'completed'
+      STATUS_CANCELED  = 'canceled'
       STATUSES = [
                    STATUS_PENDING,
                    STATUS_COMPLETED,
-                   STATUS_CANCELLED
+                   STATUS_CANCELED
                  ].freeze
 
       property :reference, type: :string
@@ -68,7 +68,7 @@ module DIDWW
 
       status_helper :pending, STATUS_PENDING
       status_helper :completed, STATUS_COMPLETED
-      status_helper :cancelled, STATUS_CANCELLED
+      status_helper :canceled, STATUS_CANCELED
 
     end
   end

--- a/spec/didww/resources/order_spec.rb
+++ b/spec/didww/resources/order_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe DIDWW::Resource::Order do
     expect(order.pending?).to be true
     order = described_class.load(status: described_class::STATUS_COMPLETED)
     expect(order.completed?).to be true
-    order = described_class.load(status: described_class::STATUS_CANCELLED)
-    expect(order.cancelled?).to be true
+    order = described_class.load(status: described_class::STATUS_CANCELED)
+    expect(order.canceled?).to be true
   end
 
   describe 'GET /orders/{id}' do

--- a/spec/support/shared_examples/requirement_validation.rb
+++ b/spec/support/shared_examples/requirement_validation.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 #
+
 # Shared examples for the two write-only "*RequirementValidation" resources
 # (AddressRequirementValidation and EmergencyRequirementValidation). Each one
 # posts an (address, identity, <requirement>) triple and the server returns
-# 204 No Content when the combination is valid or JSONAPI errors when not.
+# 201 Created with the validation resource when the combination is valid, or
+# JSONAPI errors when not.
 #
 # Callers must pass the class under test and the name of its requirement
 # relationship:
@@ -62,7 +64,7 @@ RSpec.shared_examples 'a requirement validation' do |resource_class, requirement
       requirement_class.path
     end
 
-    it 'returns 204 No Content and leaves the record unpersisted' do
+    it 'returns 201 Created with the validation resource' do
       stub_didww_request(:post, "/#{path}").with(
         body: {
           data: {
@@ -76,7 +78,14 @@ RSpec.shared_examples 'a requirement validation' do |resource_class, requirement
             }
           }
         }.to_json
-      ).to_return(status: 204, body: '', headers: json_api_headers)
+      ).to_return(
+        status: 201,
+        body: {
+          data: { id: requirement_id, type: path },
+          meta: { api_version: '2026-04-16' }
+        }.to_json,
+        headers: json_api_headers
+      )
 
       validation = resource_class.new(
         relationships: {
@@ -88,6 +97,7 @@ RSpec.shared_examples 'a requirement validation' do |resource_class, requirement
 
       expect(validation.save).to eq(true)
       expect(validation.errors).to be_empty
+      expect(validation.id).to eq(requirement_id)
     end
   end
 end


### PR DESCRIPTION
## Summary

Two post-rollout fixes uncovered while porting the Ruby 6.0 changes to other SDKs:

1. **`fix(spec): requirement validations POST returns 201 with body, not 204`** — The shared example in `spec/support/shared_examples/requirement_validation.rb` mocked a 204 No Content response and asserted an unpersisted record. Sandbox verification confirmed the server actually returns **201 Created** with a JSON:API body (`data.id` mirrors the submitted requirement id, plus `meta.api_version`). The false mock was a design smell: it locked in wrong wire expectations. Updated to stub 201+body and assert the resource is persisted with the expected id.

2. **`refactor!: rename Order.cancelled? to canceled? for wire-format consistency`** — The wire value is `"canceled"` (single L) but the helper method was `cancelled?` (double L), and the constant `STATUS_CANCELLED` also used the 2-L form. Align with the wire format. BREAKING change in 6.0.

## Verification

- Sandbox `POST /v3/emergency_requirement_validations` with a valid (Business identity + Albania address + Albania emergency_requirement) combination: `HTTP/2 201` + `{"data":{"id":"b4ca7d30-7393-44c1-9509-40d89d2d8005","type":"emergency_requirement_validations"},"meta":{"api_version":"2026-04-16"}}`.
- Server-side request specs (`apps/v3_api/spec/requests/v3/address_requirement_validations_controller_spec.rb`, `emergency_requirement_validations_controller_spec.rb`) assert `responses_with_status, 201` on all happy-path cases.

## Test plan

- [x] `bundle exec rspec spec/didww/resources/address_requirement_validation_spec.rb spec/didww/resources/emergency_requirement_validation_spec.rb` — 14 examples, 0 failures
- [x] `bundle exec rspec spec/didww/resources/order_spec.rb` — 25 examples, 0 failures (cover both `canceled?` helper and `STATUS_CANCELED` constant)
- [x] `bundle exec rspec` — 502 examples, 0 failures, 4 pending

## Breaking changes

Documented in `CHANGELOG.md` under `[Unreleased]`:
- `Order#cancelled?` → `Order#canceled?`
- `Order::STATUS_CANCELLED` → `Order::STATUS_CANCELED`