### PR TITLE
fix(sip-cascade): always emit host:nil and port:nil when enabling sip_registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2026-05-04
+### Fixed
+- `SipConfiguration#enabled_sip_registration = true` now always emits `host: null` and `port: null` on the wire, not only when the local attribute hash already had them set. The previous conditional cascade (introduced in 6.1.0) silently no-op'd when re-enabling SIP registration on an existing trunk through a fresh `SipConfiguration` instance: the PATCH body carried only `enabled_sip_registration: true`, the server merged it with the trunk's persisted host, and rejected with 422 (`host must be blank when the SIP registration is enabled`). Verified end-to-end against the live sandbox via the new `examples/voice_in_trunk_sip_registration.rb`.
+
+### Added
+- `examples/voice_in_trunk_sip_registration.rb` — end-to-end create / rename / disable / re-enable flow demonstrating every cascade rule against the sandbox API.
+
 ## [6.1.0] - 2026-05-04
 ### Added
 - Complete the 2026-04-16 `SipConfiguration` attribute set that was missed during the 2026-04-16 rollout (and is not present in the public Postman collection — server form is the source of truth):

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,7 @@ DIDWW_API_KEY=your_api_key ruby examples/orders_nanpa.rb
 | Script | Description |
 |---|---|
 | [`voice_in_trunks.rb`](voice_in_trunks.rb) | Lists voice in trunks and their configurations. |
+| [`voice_in_trunk_sip_registration.rb`](voice_in_trunk_sip_registration.rb) | End-to-end SIP registration flow: create with `enabled_sip_registration: true`, rename, disable by setting `host`, re-enable by toggling the flag. The SDK keeps the dependent fields (`host`, `port`, `use_did_in_ruri`) aligned with the server's validation rules automatically. |
 | [`voice_in_trunk_groups.rb`](voice_in_trunk_groups.rb) | CRUD for trunk groups with trunk relationships. |
 
 ### Voice Out (Outbound)

--- a/examples/voice_in_trunk_sip_registration.rb
+++ b/examples/voice_in_trunk_sip_registration.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+#
+# End-to-end SIP registration flow on /voice_in_trunks (API 2026-04-16):
+# create with sip_registration enabled → rename → disable by setting
+# `host` → re-enable by toggling the flag. The SDK keeps the
+# dependent fields (`host`, `port`, `use_did_in_ruri`) aligned with
+# the server's validation rules automatically. The sandbox trunk is
+# left in place after the script completes so it can be inspected
+# afterwards.
+#
+# Usage: DIDWW_API_KEY=your_sandbox_key ruby examples/voice_in_trunk_sip_registration.rb
+
+require 'bundler/setup'
+require 'didww'
+
+DIDWW::Client.configure do |client|
+  client.api_key  = ENV.fetch('DIDWW_API_KEY') { abort 'Please set DIDWW_API_KEY' }
+  client.api_mode = :sandbox
+end
+
+puts "=== Ruby SDK v#{DIDWW::VERSION} — SIP registration flow ==="
+
+# 1) Create a SIP trunk with sip_registration enabled. The server
+#    generates `incoming_auth_*` credentials and returns them in the
+#    response — they are read-only and stripped from any subsequent
+#    write payload by the SDK.
+puts "\n[1/4] Create with sip_registration enabled..."
+trunk = DIDWW::Client.voice_in_trunks.new(
+  name: "sip-registration-example-#{Time.now.to_i}",
+  priority: 1,
+  weight: 100,
+  cli_format: 'e164',
+  ringing_timeout: 30,
+  configuration: DIDWW::ComplexObject::SipConfiguration.new.tap do |c|
+    c.enabled_sip_registration = true
+    c.use_did_in_ruri = true
+    c.cnam_lookup = false
+    c.codec_ids = [9, 7]
+    c.transport_protocol_id = 1
+  end
+)
+abort "create failed: #{trunk.errors.full_messages.join('; ')}" unless trunk.save
+puts "  id=#{trunk.id}"
+puts "  incoming_auth_username=#{trunk.configuration.incoming_auth_username.inspect}"
+puts "  incoming_auth_password=#{trunk.configuration.incoming_auth_password.inspect}"
+trunk_id = trunk.id
+
+# 2) Rename — a single-field PATCH that doesn't touch SIP-registration state.
+puts "\n[2/4] Rename trunk..."
+trunk.name = "sip-registration-renamed-#{Time.now.to_i}"
+abort "rename failed: #{trunk.errors.full_messages.join('; ')}" unless trunk.save
+puts "  name=#{trunk.name}"
+
+# 3) Disable sip_registration by setting `host`. The SDK flips
+#    `enabled_sip_registration` and `use_did_in_ruri` to false in the
+#    same PATCH so the server-side validators accept the change.
+puts "\n[3/4] Disable by setting host..."
+trunk.configuration = DIDWW::ComplexObject::SipConfiguration.new.tap do |c|
+  c.host = '203.0.113.10'
+end
+abort "disable failed: #{trunk.errors.full_messages.join('; ')}" unless trunk.save
+fresh = DIDWW::Client.voice_in_trunks.find(trunk_id).first
+puts "  enabled_sip_registration=#{fresh.configuration.enabled_sip_registration.inspect}"
+puts "  use_did_in_ruri=#{fresh.configuration.use_did_in_ruri.inspect}"
+puts "  host=#{fresh.configuration.host.inspect}"
+puts "  incoming_auth_username=#{fresh.configuration.incoming_auth_username.inspect}"
+
+# 4) Re-enable sip_registration. Setting `enabled_sip_registration = true`
+#    sends host=nil / port=nil on the wire so the server (which still has
+#    the host from step 3) is told to clear them.
+puts "\n[4/4] Re-enable by toggling enabled_sip_registration..."
+trunk = DIDWW::Client.voice_in_trunks.find(trunk_id).first
+trunk.configuration = DIDWW::ComplexObject::SipConfiguration.new.tap do |c|
+  c.enabled_sip_registration = true
+  c.use_did_in_ruri = true
+end
+abort "re-enable failed: #{trunk.errors.full_messages.join('; ')}" unless trunk.save
+fresh = DIDWW::Client.voice_in_trunks.find(trunk_id).first
+puts "  enabled_sip_registration=#{fresh.configuration.enabled_sip_registration.inspect}"
+puts "  host=#{fresh.configuration.host.inspect}"
+puts "  incoming_auth_username=#{fresh.configuration.incoming_auth_username.inspect}"
+
+puts "\n=== PASS — trunk #{trunk_id} left in sandbox ==="

--- a/lib/didww/complex_objects/configurations/sip_configuration.rb
+++ b/lib/didww/complex_objects/configurations/sip_configuration.rb
@@ -350,12 +350,14 @@ module DIDWW
         def enabled_sip_registration=(val)
           case val
           when true
-            # Clear host/port only if they were already set — never emit a
-            # spurious `host: null` on a fresh config, which would otherwise
-            # widen every PATCH/POST body. If the trunk had a host, we have
-            # to send `host: null` explicitly so the server clears it.
-            self[:host] = nil if attributes.key?('host') && !self[:host].nil?
-            self[:port] = nil if attributes.key?('port') && !self[:port].nil?
+            # Always emit host: null and port: null on the wire when
+            # enabling sip_registration. The server requires both blank
+            # (returns 422 otherwise) AND a PATCH against an existing
+            # trunk that already has host/port set on the server side
+            # MUST explicitly nullify them — the SDK's local attributes
+            # hash starts empty, so there's nothing to "preserve".
+            self[:host] = nil
+            self[:port] = nil
           when false
             # Server requires use_did_in_ruri = false whenever sip_registration
             # is disabled. Always emit it on the wire so the server's check

--- a/lib/didww/version.rb
+++ b/lib/didww/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DIDWW
-  VERSION = '6.1.0'.freeze
+  VERSION = '6.1.1'.freeze
 end

--- a/spec/didww/complex_objects/sip_configuration_spec.rb
+++ b/spec/didww/complex_objects/sip_configuration_spec.rb
@@ -195,6 +195,23 @@ RSpec.describe DIDWW::ComplexObject::SipConfiguration do
       expect(attrs['use_did_in_ruri']).to be(false)
     end
 
+    # Regression for 6.1.0: PATCH against an existing trunk that already has
+    # a host on the server side. The local SipConfiguration starts empty, so
+    # nothing is in the local attributes hash. Setting
+    # `enabled_sip_registration = true` must still emit `host: null` /
+    # `port: null` on the wire — otherwise the server merges the new field
+    # with the persisted host and rejects with 422.
+    it 'emits host=nil and port=nil even on a fresh config when enabling sip_registration' do
+      cfg = described_class.new
+      cfg.enabled_sip_registration = true
+      attrs = cfg.as_json[:attributes]
+      expect(attrs).to have_key('host')
+      expect(attrs['host']).to be_nil
+      expect(attrs).to have_key('port')
+      expect(attrs['port']).to be_nil
+      expect(attrs['enabled_sip_registration']).to be(true)
+    end
+
     it 'constructor-time assignment bypasses the cascade so server responses deserialize as-is' do
       # Server may return a regular SIP trunk shape (host: present together
       # with use_did_in_ruri: true). The constructor uses []= directly,

--- a/spec/didww/resources/voice_in_trunk_spec.rb
+++ b/spec/didww/resources/voice_in_trunk_spec.rb
@@ -364,6 +364,11 @@ RSpec.describe DIDWW::Resource::VoiceInTrunk do
                   "configuration": {
                     "type": 'sip_configurations',
                     "attributes": {
+                      # Setting `enabled_sip_registration = true` always
+                      # cascades host: nil and port: nil on the wire so the
+                      # server clears whatever it had persisted.
+                      "host": nil,
+                      "port": nil,
                       "enabled_sip_registration": true,
                       "use_did_in_ruri": true,
                       "cnam_lookup": true,
@@ -695,6 +700,12 @@ RSpec.describe DIDWW::Resource::VoiceInTrunk do
                   "configuration": {
                     "type": 'sip_configurations',
                     "attributes": {
+                      # Setting `enabled_sip_registration = true` always
+                      # cascades host: nil and port: nil on the wire so the
+                      # server clears the values it had persisted on the
+                      # existing trunk.
+                      "host": nil,
+                      "port": nil,
                       "enabled_sip_registration": true,
                       "use_did_in_ruri": true,
                       "cnam_lookup": true,


### PR DESCRIPTION
## Bug

Sandbox testing of `enabled_sip_registration` re-enable flow against an existing trunk returns `422 Host must be blank when the SIP registration is enabled`:

```ruby
# trunk on the server has host=203.0.113.10 from a prior PATCH that disabled sip_registration
trunk = client.voice_in_trunks.find(trunk_id).first
trunk.configuration = DIDWW::ComplexObject::SipConfiguration.new.tap do |c|
  c.enabled_sip_registration = true
  c.use_did_in_ruri = true
end
trunk.save  # => false; server returns 422
```

## Root cause

The cascade introduced in 6.1.0 was conditional:

```ruby
when true
  self[:host] = nil if attributes.key?('host') && !self[:host].nil?
  self[:port] = nil if attributes.key?('port') && !self[:port].nil?
```

The intent was to avoid spurious `host: null` / `port: null` keys on a fresh-config PATCH body. But the local attributes hash starts EMPTY whenever the caller constructs a new `SipConfiguration`, so the cascade no-ops, the PATCH body carries only `enabled_sip_registration: true`, and the server merges it with whatever host/port the trunk already had — which is exactly what the validators reject.

## Fix

Drop the conditional. Setting `enabled_sip_registration = true` now ALWAYS emits `host: null` and `port: null` on the wire. The slightly wider request body is the correct shape for the server's validators in every case (the API requires both blank when sip_registration is on; sending them as null is the documented way to clear server-side state).

## Verification

- `bundle exec rspec` — 531 examples, 0 failures (one new regression spec for the fresh-config case + two existing PATCH/POST stub bodies updated to include the cascaded host/port fields).
- New `examples/voice_in_trunk_sip_registration.rb` — runs the full create / rename / disable / re-enable flow end-to-end against the live sandbox, all four steps PASS.

## Versioning

Bumped to **6.1.1** (patch — bug fix only, no API surface change).

## Test plan

- [x] Local rspec green
- [x] Sandbox example PASSed (create + rename + disable + re-enable)
- [x] CI green
- [ ] After merge: tag v6.1.1, `gem build && gem push`, GitHub release.
