### PR TITLE
fix: rename propated_mrc → prorated_mrc on DID/Capacity order items

### DIFF
--- a/lib/didww/complex_objects/capacity_order_item.rb
+++ b/lib/didww/complex_objects/capacity_order_item.rb
@@ -9,7 +9,7 @@ module DIDWW
       # returned
       property :nrc,                type: :decimal
       property :mrc,                type: :decimal
-      property :propated_mrc,       type: :boolean
+      property :prorated_mrc,       type: :boolean
       property :billed_from,        type: :string
       property :billed_to,          type: :string
     end

--- a/lib/didww/complex_objects/did_order_item.rb
+++ b/lib/didww/complex_objects/did_order_item.rb
@@ -15,7 +15,7 @@ module DIDWW
       property :monthly_price,        type: :decimal
       property :nrc,                  type: :decimal
       property :mrc,                  type: :decimal
-      property :propated_mrc,         type: :boolean
+      property :prorated_mrc,         type: :boolean
       property :billed_from,          type: :string
       property :billed_to,            type: :string
       property :did_group_id,         type: :string


### PR DESCRIPTION
`prorated_mrc` is server-returned in order-item response bodies. The misspelled SDK property (`propated_mrc`) was never populated from API responses — the deserializer matches by JSON key name. `EmergencyOrderItem` already used the correct spelling.