### PR TITLE
feat: add rtp_ping attribute to VoiceOutTrunk

### DIFF
--- a/lib/didww/resource/voice_out_trunk.rb
+++ b/lib/didww/resource/voice_out_trunk.rb
@@ -64,6 +64,7 @@ module DIDWW
       property :media_encryption_mode, type: :string
       property :callback_url, type: :string
       property :force_symmetric_rtp, type: :boolean
+      property :rtp_ping, type: :boolean
       property :allowed_rtp_ips, type: :ip_addresses
 
       # Type: String

--- a/spec/didww/resources/voice_out_trunk_spec.rb
+++ b/spec/didww/resources/voice_out_trunk_spec.rb
@@ -149,6 +149,10 @@ RSpec.describe DIDWW::Resource::VoiceOutTrunk do
         it '"rtp_timeout", type: Integer' do
           expect(trunk.rtp_timeout).to be_kind_of(Integer)
         end
+
+        it '"rtp_ping", type: Boolean' do
+          expect(trunk.rtp_ping).to be_in([true, false])
+        end
       end
     end
 

--- a/spec/fixtures/voice_out_trunks/get/without_includes/200.json
+++ b/spec/fixtures/voice_out_trunks/get/without_includes/200.json
@@ -17,6 +17,7 @@
         "media_encryption_mode": "disabled",
         "callback_url": null,
         "force_symmetric_rtp": false,
+        "rtp_ping": false,
         "allowed_rtp_ips": [],
         "authentication_method": {
           "type": "credentials_and_ip",

--- a/spec/fixtures/voice_out_trunks/id/get/without_includes/200.json
+++ b/spec/fixtures/voice_out_trunks/id/get/without_includes/200.json
@@ -16,6 +16,7 @@
       "media_encryption_mode": "disabled",
       "callback_url": null,
       "force_symmetric_rtp": false,
+      "rtp_ping": false,
       "allowed_rtp_ips": [],
       "external_reference_id": "crm-vot-0001",
       "emergency_enable_all": false,

--- a/spec/fixtures/voice_out_trunks/id/patch/update_attributes/200.json
+++ b/spec/fixtures/voice_out_trunks/id/patch/update_attributes/200.json
@@ -16,6 +16,7 @@
       "media_encryption_mode": "disabled",
       "callback_url": null,
       "force_symmetric_rtp": false,
+      "rtp_ping": false,
       "allowed_rtp_ips": [],
       "authentication_method": {
         "type": "credentials_and_ip",

--- a/spec/fixtures/voice_out_trunks/id/patch/update_emergency_dids/200.json
+++ b/spec/fixtures/voice_out_trunks/id/patch/update_emergency_dids/200.json
@@ -16,6 +16,7 @@
       "media_encryption_mode": "disabled",
       "callback_url": null,
       "force_symmetric_rtp": false,
+      "rtp_ping": false,
       "allowed_rtp_ips": [],
       "emergency_enable_all": false,
       "rtp_timeout": 30,

--- a/spec/fixtures/voice_out_trunks/post/create_trunk/201.json
+++ b/spec/fixtures/voice_out_trunks/post/create_trunk/201.json
@@ -16,6 +16,7 @@
       "media_encryption_mode": "disabled",
       "callback_url": null,
       "force_symmetric_rtp": false,
+      "rtp_ping": false,
       "allowed_rtp_ips": [],
       "external_reference_id": null,
       "emergency_enable_all": false,


### PR DESCRIPTION
The DIDWW API exposes a boolean rtp_ping (RTP keep-alive) on VoiceOutTrunk, and every other DIDWW SDK (.NET, Python, TypeScript, Go) declares it. The Ruby SDK was the only one missing the property, so consumers could neither read it from GET responses nor toggle it via POST/PATCH. Changes: lib/didww/resource/voice_out_trunk.rb declares property :rtp_ping, type: :boolean; spec adds a test asserting rtp_ping is exposed as a boolean on GET; spec/fixtures/voice_out_trunks/** backfills rtp_ping into every response fixture so coverage is consistent.