### PR TITLE
feat: add description attribute to DidReservation

### DIFF
--- a/lib/didww/resource/did_reservation.rb
+++ b/lib/didww/resource/did_reservation.rb
@@ -12,6 +12,10 @@ module DIDWW
       # Type: DateTime
       # Description: DID reservation created at DateTime.
 
+      property :description, type: :string
+      # Type: String
+      # Description: Customer-supplied note attached to the reservation.
+      # Writable on POST; returned on subsequent GETs.
     end
   end
 end

--- a/spec/didww/resources/did_reservation_spec.rb
+++ b/spec/didww/resources/did_reservation_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe DIDWW::Resource::DidReservation do
         expect(record).to be_kind_of(DIDWW::Resource::DidReservation)
         expect(record.expires_at).to be_kind_of(Time)
         expect(record.created_at).to be_kind_of(Time)
+        expect(record.description).to eq('DIDWW')
       end
     end
 


### PR DESCRIPTION
Closes Ruby SDK gap on DidReservation.description. The DIDWW API accepts the field on POST and echoes it back on GET, and every other DIDWW SDK exposes it; the Ruby SDK was the only one missing the property declaration. Declared property :description, type: :string on the resource. Added a spec asserting record.description is read from the GET fixture (which already carried description: DIDWW). Tests: bundle exec rspec 532/0 (4 pending), bundle exec rubocop clean.