### PR TITLE
fix(fixtures): correct malformed and production hosts in recorded responses

### DIFF
--- a/spec/fixtures/did_group_types/get/without_includes/200.json
+++ b/spec/fixtures/did_group_types/get/without_includes/200.json
@@ -47,7 +47,7 @@
     "total_records": 6
   },
   "links": {
-    "first": "https://sandbox-api.didww.comv3/did_group_types?page%5Bnumber%5D=1&page%5Bsize%5D=50",
+    "first": "https://sandbox-api.didww.com/v3/did_group_types?page%5Bnumber%5D=1&page%5Bsize%5D=50",
     "last": "https://sandbox-api.didww.com/v3/did_group_types?page%5Bnumber%5D=1&page%5Bsize%5D=50"
   }
 }

--- a/spec/fixtures/proofs/get/without_includes/200.json
+++ b/spec/fixtures/proofs/get/without_includes/200.json
@@ -11,14 +11,14 @@
       "relationships": {
         "proof_type": {
           "links": {
-            "self": "https://api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/relationships/proof_type",
-            "related": "https://api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/proof_type"
+            "self": "https://sandbox-api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/relationships/proof_type",
+            "related": "https://sandbox-api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/proof_type"
           }
         },
         "entity": {
           "links": {
-            "self": "https://api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/relationships/entity",
-            "related": "https://api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/entity"
+            "self": "https://sandbox-api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/relationships/entity",
+            "related": "https://sandbox-api.didww.com/v3/proofs/84155378-88d5-456e-844d-103596e3fb2c/entity"
           }
         }
       }
@@ -34,14 +34,14 @@
       "relationships": {
         "proof_type": {
           "links": {
-            "self": "https://api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/relationships/proof_type",
-            "related": "https://api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/proof_type"
+            "self": "https://sandbox-api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/relationships/proof_type",
+            "related": "https://sandbox-api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/proof_type"
           }
         },
         "entity": {
           "links": {
-            "self": "https://api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/relationships/entity",
-            "related": "https://api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/entity"
+            "self": "https://sandbox-api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/relationships/entity",
+            "related": "https://sandbox-api.didww.com/v3/proofs/95266489-99e6-567f-955e-214707f4ac3d/entity"
           }
         }
       }

--- a/spec/fixtures/supporting_document_templates/get/without_includes/200.json
+++ b/spec/fixtures/supporting_document_templates/get/without_includes/200.json
@@ -6,7 +6,7 @@
       "attributes": {
         "name": "Generic LOI",
         "permanent": false,
-        "url": "https://api.didww.com/storage/public/w7f2irbo819la7vd7up7u67pkmkn"
+        "url": "https://sandbox-api.didww.com/storage/public/w7f2irbo819la7vd7up7u67pkmkn"
       }
     },
     {
@@ -15,7 +15,7 @@
       "attributes": {
         "name": "Belgium Registration Form",
         "permanent": true,
-        "url": "https://api.didww.com/storage/public/e8lziulj68xetfa5ed6na3g7q7ra"
+        "url": "https://sandbox-api.didww.com/storage/public/e8lziulj68xetfa5ed6na3g7q7ra"
       }
     }
   ],


### PR DESCRIPTION
Fixture hygiene follow-up to #87, aligned with the same cleanup across the other SDKs:

- `did_group_types/get/without_includes/200.json`: the `first` pagination link read `https://sandbox-api.didww.comv3/...` — missing slash before `v3`.
- `proofs/get/without_includes/200.json` and `supporting_document_templates/get/without_includes/200.json`: relationship links and storage URLs pointed at the production host; switched to `sandbox-api.didww.com` like every other fixture.

rspec green, rubocop clean.