### PR TITLE
fix: relax json_api_client pin to support Ruby 4.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.3', '3.4' ]
+        ruby: [ '3.3', '3.4', '4.0' ]
         rails: [ '~> 7.2', '~> 8.0', '~> 8.1' ]
     name: Tests with Ruby ${{ matrix.ruby }} Activesupport ${{ matrix.rails }}
     env:

--- a/didww-v3.gemspec
+++ b/didww-v3.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport',     '>= 7.2', '< 9'
   spec.add_dependency 'faraday',           '~> 2.0'
   spec.add_dependency 'faraday-multipart', '~> 1.0'
-  spec.add_dependency 'json_api_client',   '1.23.0'
+  spec.add_dependency 'json_api_client',   '~> 1.23'
   spec.add_dependency 'http',              '~> 5.0'
   spec.add_dependency 'down',              '~> 5.0'
   spec.add_dependency 'openssl-oaep',      '~> 0.1'


### PR DESCRIPTION
Fixes #89.

