### PR TITLE
test: cover create/update with relationship includes

### DIFF
--- a/spec/didww/resources/shared_capacity_group_spec.rb
+++ b/spec/didww/resources/shared_capacity_group_spec.rb
@@ -200,7 +200,52 @@ RSpec.describe DIDWW::Resource::SharedCapacityGroup do
         expect(shared_capacity_group).to be_persisted
       end
 
-      xit 'creates a SharedCapacityGroup, assign Dids and include them in response'
+      it 'creates a SharedCapacityGroup, assign Dids and include them in response' do
+        stub_didww_request(:post, '/shared_capacity_groups?include=dids').
+          with(body:
+            {
+              "data": {
+                "type": 'shared_capacity_groups',
+                "relationships": {
+                  "capacity_pool": {
+                    "data": {
+                      "type": 'capacity_pools',
+                      "id": '71185c2a-fcc7-468b-87e3-85260fbc3b86'
+                    }
+                  },
+                  "dids": {
+                    "data": [
+                      {
+                        "type": 'dids',
+                        "id": 'c208e97e-d3ce-4be6-ba48-ffb459f64ec0'
+                      }
+                    ]
+                  }
+                },
+                "attributes": {
+                  "name": 'Sample Capacity Group',
+                  "shared_channels_count": 3,
+                  "metered_channels_count": 5
+                }
+              }
+            }.to_json).
+          to_return(
+            status: 201,
+            body: api_fixture('shared_capacity_groups/post/create_with_dids_included/201'),
+            headers: json_api_headers
+          )
+
+        shared_capacity_group = client.shared_capacity_groups.new(name: 'Sample Capacity Group', shared_channels_count: 3, metered_channels_count: 5)
+        shared_capacity_group.relationships[:capacity_pool] = DIDWW::Resource::CapacityPool.load(id: '71185c2a-fcc7-468b-87e3-85260fbc3b86')
+        shared_capacity_group.relationships[:dids] = [
+          DIDWW::Resource::Did.load(id: 'c208e97e-d3ce-4be6-ba48-ffb459f64ec0')
+        ]
+        shared_capacity_group.request_includes(:dids)
+        shared_capacity_group.save
+        expect(shared_capacity_group).to be_persisted
+        expect(shared_capacity_group.dids).to all(be_kind_of(DIDWW::Resource::Did))
+        expect(shared_capacity_group.dids.map(&:id)).to contain_exactly('c208e97e-d3ce-4be6-ba48-ffb459f64ec0')
+      end
     end
 
     describe 'with incorrect attributes' do

--- a/spec/didww/resources/voice_in_trunk_group_spec.rb
+++ b/spec/didww/resources/voice_in_trunk_group_spec.rb
@@ -179,7 +179,57 @@ RSpec.describe DIDWW::Resource::VoiceInTrunkGroup do
         expect(trunk_group).to be_persisted
       end
 
-      xit 'creates a TrunkGroup, assign Trunks and include them in response'
+      it 'creates a TrunkGroup, assign Trunks and include them in response' do
+        stub_didww_request(:post, '/voice_in_trunk_groups?include=voice_in_trunks').
+          with(body:
+            {
+              "data": {
+                "type": 'voice_in_trunk_groups',
+                "relationships": {
+                  "voice_in_trunks": {
+                    "data": [
+                      {
+                        "type": 'voice_in_trunks',
+                        "id": '4380d9a3-0b04-4da3-8383-0fdf43c27fc5'
+                      },
+                      {
+                        "type": 'voice_in_trunks',
+                        "id": '82d6875a-d84f-4d18-a47f-d2f470c074fd'
+                      },
+                      {
+                        "type": 'voice_in_trunks',
+                        "id": 'b2baa741-e886-499f-8e43-760c3fdd2924'
+                      }
+                    ]
+                  }
+                },
+                "attributes": {
+                  "name": 'Main group',
+                  "capacity_limit": 100
+                }
+              }
+            }.to_json).
+          to_return(
+            status: 201,
+            body: api_fixture('voice_in_trunk_groups/post/create_with_trunks_included/201'),
+            headers: json_api_headers
+          )
+        trunk_group = client.voice_in_trunk_groups.new(name: 'Main group', capacity_limit: 100)
+        trunk_group.relationships[:voice_in_trunks] = [
+          DIDWW::Resource::VoiceInTrunk.load(id: '4380d9a3-0b04-4da3-8383-0fdf43c27fc5'),
+          DIDWW::Resource::VoiceInTrunk.load(id: '82d6875a-d84f-4d18-a47f-d2f470c074fd'),
+          DIDWW::Resource::VoiceInTrunk.load(id: 'b2baa741-e886-499f-8e43-760c3fdd2924')
+        ]
+        trunk_group.request_includes(:voice_in_trunks)
+        trunk_group.save
+        expect(trunk_group).to be_persisted
+        expect(trunk_group.voice_in_trunks).to all(be_kind_of(DIDWW::Resource::VoiceInTrunk))
+        expect(trunk_group.voice_in_trunks.map(&:id)).to contain_exactly(
+          '4380d9a3-0b04-4da3-8383-0fdf43c27fc5',
+          '82d6875a-d84f-4d18-a47f-d2f470c074fd',
+          'b2baa741-e886-499f-8e43-760c3fdd2924'
+        )
+      end
     end
 
     describe 'when creating TrunkGroup with trunks and name already taken' do

--- a/spec/didww/resources/voice_in_trunk_spec.rb
+++ b/spec/didww/resources/voice_in_trunk_spec.rb
@@ -513,7 +513,80 @@ RSpec.describe DIDWW::Resource::VoiceInTrunk do
         expect(trunk.pop).to be_kind_of(DIDWW::Resource::Pop)
       end
 
-      xit 'creates a SIP trunk with assigning to pop and including it to response'
+      it 'creates a SIP trunk with assigning to pop and including it to response' do
+        stub_didww_request(:post, '/voice_in_trunks?include=pop').
+          with(body:
+            {
+              "data": {
+                "type": 'voice_in_trunks',
+                "relationships": {
+                  "pop": {
+                    "data": {
+                      "type": 'pops',
+                      "id": 'b4d3ec87-8b2b-4e91-bcda-da67db8a76ca'
+                    }
+                  }
+                },
+                "attributes": {
+                  "name": 'Office SIP',
+                  "capacity_limit": 18,
+                  "cli_format": 'e164',
+                  "cli_prefix": '+1',
+                  "configuration": {
+                    "type": 'sip_configurations',
+                    "attributes": base_sip_config_attributes
+                  }
+                }
+              }
+            }.to_json).
+          to_return(
+            status: 201,
+            body: api_fixture('voice_in_trunks/post/create_sip_trunk_with_pop_included/201'),
+            headers: json_api_headers
+          )
+        trunk = client.voice_in_trunks.new(
+                    name: 'Office SIP',
+                    capacity_limit: 18,
+                    cli_format: 'e164',
+                    cli_prefix: '+1',
+                  )
+        trunk.configuration = DIDWW::ComplexObject::SipConfiguration.new.tap do |c|
+          c.username = 'username'
+          c.host = 'example.com'
+          c.codec_ids = [ 9, 7 ]
+          c.rx_dtmf_format_id = 1
+          c.tx_dtmf_format_id = 1
+          c.resolve_ruri = 'true'
+          c.auth_enabled = true
+          c.auth_user = 'username'
+          c.auth_password = 'password'
+          c.auth_from_user = 'Office'
+          c.auth_from_domain = 'example.com'
+          c.sst_enabled = 'false'
+          c.sst_min_timer = 600
+          c.sst_max_timer = 900
+          c.sst_refresh_method_id = 1
+          c.sst_accept_501 = 'true'
+          c.sip_timer_b = 8000
+          c.dns_srv_failover_timer = 2000
+          c.rtp_ping = 'false'
+          c.rtp_timeout = 30
+          c.force_symmetric_rtp = 'false'
+          c.symmetric_rtp_ignore_rtcp = 'false'
+          c.rerouting_disconnect_code_ids = [ 58, 59 ]
+          c.port = 5060
+          c.transport_protocol_id = 2
+          c.max_transfers = 0
+          c.max_30x_redirects = 0
+        end
+        trunk.relationships[:pop] = DIDWW::Resource::Pop.load(id: 'b4d3ec87-8b2b-4e91-bcda-da67db8a76ca')
+        trunk.request_includes(:pop)
+        trunk.save
+        expect(trunk).to be_persisted
+        expect(trunk.configuration).to be_kind_of(DIDWW::ComplexObject::SipConfiguration)
+        expect(trunk.pop).to be_kind_of(DIDWW::Resource::Pop)
+        expect(trunk.pop.id).to eq('b4d3ec87-8b2b-4e91-bcda-da67db8a76ca')
+      end
 
     end
 
@@ -858,7 +931,41 @@ RSpec.describe DIDWW::Resource::VoiceInTrunk do
         expect(trunk.pop).to be_kind_of(DIDWW::Resource::Pop)
       end
 
-      xit 'updates a SIP Trunk, with assigning to pop and including it to response'
+      it 'updates a SIP Trunk, with assigning to pop and including it to response' do
+        id = '204f6568-a583-40ef-9bef-fff02273b183'
+        stub_didww_request(:patch, "/voice_in_trunks/#{id}?include=pop").
+          with(body:
+            {
+              "data": {
+                "id": '204f6568-a583-40ef-9bef-fff02273b183',
+                "type": 'voice_in_trunks',
+                "relationships": {
+                  "pop": {
+                    "data": {
+                      "type": 'pops',
+                      "id": 'b4d3ec87-8b2b-4e91-bcda-da67db8a76ca'
+                    }
+                  }
+                },
+                "attributes": {
+                  "name": 'New trunk'
+                }
+              }
+            }.to_json).
+          to_return(
+            status: 200,
+            body: api_fixture('voice_in_trunks/post/create_sip_trunk_with_pop_included/201'),
+            headers: json_api_headers
+          )
+        trunk = DIDWW::Resource::VoiceInTrunk.load(id: id)
+        trunk.name = 'New trunk'
+        trunk.relationships.pop = DIDWW::Resource::Pop.load(id: 'b4d3ec87-8b2b-4e91-bcda-da67db8a76ca')
+        trunk.request_includes(:pop)
+        trunk.save
+        expect(trunk.errors).to be_empty
+        expect(trunk.pop).to be_kind_of(DIDWW::Resource::Pop)
+        expect(trunk.pop.id).to eq('b4d3ec87-8b2b-4e91-bcda-da67db8a76ca')
+      end
 
     end
 

--- a/spec/fixtures/shared_capacity_groups/post/create_with_dids_included/201.json
+++ b/spec/fixtures/shared_capacity_groups/post/create_with_dids_included/201.json
@@ -1,0 +1,118 @@
+{
+  "data": {
+    "id": "e258a0d6-b02f-4d15-913e-fc79e7baeea9",
+    "type": "shared_capacity_groups",
+    "attributes": {
+      "name": "11",
+      "shared_channels_count": 0,
+      "created_at": "2018-06-19T11:41:21.644Z",
+      "metered_channels_count": 0,
+      "external_reference_id": null
+    },
+    "relationships": {
+      "capacity_pool": {
+        "links": {
+          "self": "https://sandbox-api.didww.com/v3/shared_capacity_groups/e258a0d6-b02f-4d15-913e-fc79e7baeea9/relationships/capacity_pool",
+          "related": "https://sandbox-api.didww.com/v3/shared_capacity_groups/e258a0d6-b02f-4d15-913e-fc79e7baeea9/capacity_pool"
+        }
+      },
+      "dids": {
+        "links": {
+          "self": "https://sandbox-api.didww.com/v3/shared_capacity_groups/e258a0d6-b02f-4d15-913e-fc79e7baeea9/relationships/dids",
+          "related": "https://sandbox-api.didww.com/v3/shared_capacity_groups/e258a0d6-b02f-4d15-913e-fc79e7baeea9/dids"
+        },
+        "data": [
+          {
+            "type": "dids",
+            "id": "c208e97e-d3ce-4be6-ba48-ffb459f64ec0"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "c208e97e-d3ce-4be6-ba48-ffb459f64ec0",
+      "type": "dids",
+      "attributes": {
+        "blocked": false,
+        "capacity_limit": 5,
+        "description": "Hi",
+        "terminated": false,
+        "awaiting_registration": false,
+        "created_at": "2026-04-22T17:46:03.000Z",
+        "billing_cycles_count": null,
+        "number": "12015550100",
+        "expires_at": "2026-06-22T17:47:00.208Z",
+        "channels_included_count": 0,
+        "dedicated_channels_count": 1,
+        "emergency_enabled": false
+      },
+      "relationships": {
+        "did_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/did_group",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/did_group"
+          }
+        },
+        "order": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/order",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/order"
+          }
+        },
+        "capacity_pool": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/capacity_pool",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/capacity_pool"
+          }
+        },
+        "shared_capacity_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/shared_capacity_group",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/shared_capacity_group"
+          }
+        },
+        "address_verification": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/address_verification",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/address_verification"
+          }
+        },
+        "voice_in_trunk": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/voice_in_trunk",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/voice_in_trunk"
+          }
+        },
+        "voice_in_trunk_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/voice_in_trunk_group",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/voice_in_trunk_group"
+          }
+        },
+        "emergency_calling_service": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/emergency_calling_service",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/emergency_calling_service"
+          }
+        },
+        "emergency_verification": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/emergency_verification",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/emergency_verification"
+          }
+        },
+        "identity": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/relationships/identity",
+            "related": "https://sandbox-api.didww.com/v3/dids/c208e97e-d3ce-4be6-ba48-ffb459f64ec0/identity"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "api_version": "2026-04-16"
+  }
+}

--- a/spec/fixtures/voice_in_trunk_groups/post/create_with_trunks_included/201.json
+++ b/spec/fixtures/voice_in_trunk_groups/post/create_with_trunks_included/201.json
@@ -1,0 +1,238 @@
+{
+  "data": {
+    "id": "709e77ec-eeb2-4527-88a9-4572c6a8fe3d",
+    "type": "voice_in_trunk_groups",
+    "attributes": {
+      "created_at": "2016-03-22T12:05:44.600Z",
+      "name": "trunk_group ololol",
+      "capacity_limit": 100,
+      "external_reference_id": null
+    },
+    "relationships": {
+      "voice_in_trunks": {
+        "links": {
+          "self": "https://sandbox-api.didww.com/v3/voice_in_trunk_groups/709e77ec-eeb2-4527-88a9-4572c6a8fe3d/relationships/voice_in_trunks",
+          "related": "https://sandbox-api.didww.com/v3/voice_in_trunk_groups/709e77ec-eeb2-4527-88a9-4572c6a8fe3d/voice_in_trunks"
+        },
+        "data": [
+          {
+            "type": "voice_in_trunks",
+            "id": "4380d9a3-0b04-4da3-8383-0fdf43c27fc5"
+          },
+          {
+            "type": "voice_in_trunks",
+            "id": "82d6875a-d84f-4d18-a47f-d2f470c074fd"
+          },
+          {
+            "type": "voice_in_trunks",
+            "id": "b2baa741-e886-499f-8e43-760c3fdd2924"
+          }
+        ]
+      }
+    },
+    "meta": {
+      "trunks_count": 4
+    }
+  },
+  "included": [
+    {
+      "id": "4380d9a3-0b04-4da3-8383-0fdf43c27fc5",
+      "type": "voice_in_trunks",
+      "attributes": {
+        "external_reference_id": null,
+        "priority": 20,
+        "capacity_limit": 77,
+        "weight": 65535,
+        "name": "yyy1",
+        "cli_format": "raw",
+        "cli_prefix": "",
+        "description": "",
+        "ringing_timeout": null,
+        "configuration": {
+          "type": "sip_configurations",
+          "attributes": {
+            "username": "{DID}",
+            "host": "didww.com",
+            "port": null,
+            "codec_ids": [
+              9,
+              10,
+              8,
+              7,
+              6
+            ],
+            "rx_dtmf_format_id": 1,
+            "tx_dtmf_format_id": 1,
+            "resolve_ruri": false,
+            "auth_enabled": false,
+            "auth_user": "",
+            "auth_password": "",
+            "auth_from_user": "",
+            "auth_from_domain": "",
+            "sst_enabled": false,
+            "sst_min_timer": 600,
+            "sst_max_timer": 900,
+            "sst_accept_501": true,
+            "sip_timer_b": 8000,
+            "dns_srv_failover_timer": 2000,
+            "rtp_ping": false,
+            "rtp_timeout": 30,
+            "force_symmetric_rtp": false,
+            "symmetric_rtp_ignore_rtcp": false,
+            "rerouting_disconnect_code_ids": [],
+            "sst_session_expires": null,
+            "sst_refresh_method_id": 1,
+            "transport_protocol_id": 1,
+            "max_transfers": 0,
+            "max_30x_redirects": 0,
+            "media_encryption_mode": "disabled",
+            "stir_shaken_mode": "disabled",
+            "allowed_rtp_ips": null,
+            "network_protocol_priority": "force_ipv4",
+            "enabled_sip_registration": false,
+            "use_did_in_ruri": false,
+            "diversion_relay_policy": "none",
+            "diversion_inject_mode": "did_number",
+            "cnam_lookup": false,
+            "incoming_auth_username": null,
+            "incoming_auth_password": null
+          }
+        },
+        "created_at": "2016-04-14T09:29:17.930Z"
+      },
+      "relationships": {
+        "voice_in_trunk_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/4380d9a3-0b04-4da3-8383-0fdf43c27fc5/relationships/voice_in_trunk_group",
+            "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/4380d9a3-0b04-4da3-8383-0fdf43c27fc5/voice_in_trunk_group"
+          }
+        },
+        "pop": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/4380d9a3-0b04-4da3-8383-0fdf43c27fc5/relationships/pop",
+            "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/4380d9a3-0b04-4da3-8383-0fdf43c27fc5/pop"
+          }
+        }
+      }
+    },
+    {
+      "id": "82d6875a-d84f-4d18-a47f-d2f470c074fd",
+      "type": "voice_in_trunks",
+      "attributes": {
+        "external_reference_id": null,
+        "priority": 25,
+        "capacity_limit": 2,
+        "weight": 65535,
+        "name": "test pstn",
+        "cli_format": "e164",
+        "cli_prefix": null,
+        "description": null,
+        "ringing_timeout": null,
+        "configuration": {
+          "type": "pstn_configurations",
+          "attributes": {
+            "dst": "3806723432423"
+          }
+        },
+        "created_at": "2018-08-16T14:31:33.565Z"
+      },
+      "relationships": {
+        "voice_in_trunk_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/82d6875a-d84f-4d18-a47f-d2f470c074fd/relationships/voice_in_trunk_group",
+            "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/82d6875a-d84f-4d18-a47f-d2f470c074fd/voice_in_trunk_group"
+          }
+        },
+        "pop": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/82d6875a-d84f-4d18-a47f-d2f470c074fd/relationships/pop",
+            "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/82d6875a-d84f-4d18-a47f-d2f470c074fd/pop"
+          }
+        }
+      }
+    },
+    {
+      "id": "b2baa741-e886-499f-8e43-760c3fdd2924",
+      "type": "voice_in_trunks",
+      "attributes": {
+        "external_reference_id": null,
+        "priority": 20,
+        "capacity_limit": null,
+        "weight": 65535,
+        "name": "test2342343266",
+        "cli_format": "raw",
+        "cli_prefix": "4",
+        "description": null,
+        "ringing_timeout": 25,
+        "configuration": {
+          "type": "sip_configurations",
+          "attributes": {
+            "username": "test",
+            "host": "didww.com",
+            "port": null,
+            "codec_ids": [
+              9,
+              10,
+              8,
+              7,
+              6
+            ],
+            "rx_dtmf_format_id": 1,
+            "tx_dtmf_format_id": 1,
+            "resolve_ruri": false,
+            "auth_enabled": false,
+            "auth_user": null,
+            "auth_password": null,
+            "auth_from_user": null,
+            "auth_from_domain": null,
+            "sst_enabled": false,
+            "sst_min_timer": 600,
+            "sst_max_timer": 900,
+            "sst_accept_501": true,
+            "sip_timer_b": 8000,
+            "dns_srv_failover_timer": 2000,
+            "rtp_ping": false,
+            "rtp_timeout": 30,
+            "force_symmetric_rtp": false,
+            "symmetric_rtp_ignore_rtcp": false,
+            "rerouting_disconnect_code_ids": null,
+            "sst_session_expires": null,
+            "sst_refresh_method_id": 1,
+            "transport_protocol_id": 1,
+            "max_transfers": 0,
+            "max_30x_redirects": 0,
+            "media_encryption_mode": "disabled",
+            "stir_shaken_mode": "disabled",
+            "allowed_rtp_ips": null,
+            "network_protocol_priority": "force_ipv4",
+            "enabled_sip_registration": false,
+            "use_did_in_ruri": false,
+            "diversion_relay_policy": "none",
+            "diversion_inject_mode": "did_number",
+            "cnam_lookup": false,
+            "incoming_auth_username": null,
+            "incoming_auth_password": null
+          }
+        },
+        "created_at": "2016-03-03T08:46:28.184Z"
+      },
+      "relationships": {
+        "voice_in_trunk_group": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/b2baa741-e886-499f-8e43-760c3fdd2924/relationships/voice_in_trunk_group",
+            "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/b2baa741-e886-499f-8e43-760c3fdd2924/voice_in_trunk_group"
+          }
+        },
+        "pop": {
+          "links": {
+            "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/b2baa741-e886-499f-8e43-760c3fdd2924/relationships/pop",
+            "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/b2baa741-e886-499f-8e43-760c3fdd2924/pop"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "api_version": "2026-04-16"
+  }
+}

--- a/spec/fixtures/voice_in_trunks/post/create_sip_trunk_with_pop_included/201.json
+++ b/spec/fixtures/voice_in_trunks/post/create_sip_trunk_with_pop_included/201.json
@@ -1,0 +1,97 @@
+{
+  "data": {
+    "id": "204f6568-a583-40ef-9bef-fff02273b183",
+    "type": "voice_in_trunks",
+    "attributes": {
+      "external_reference_id": null,
+      "priority": 10,
+      "capacity_limit": 1000,
+      "weight": 65535,
+      "name": "35",
+      "cli_format": "raw",
+      "cli_prefix": "",
+      "description": null,
+      "ringing_timeout": null,
+      "configuration": {
+        "type": "sip_configurations",
+        "attributes": {
+          "username": "dfds77",
+          "host": "df.oc",
+          "port": null,
+          "codec_ids": [
+            9,
+            10,
+            8,
+            7
+          ],
+          "rx_dtmf_format_id": 1,
+          "tx_dtmf_format_id": 1,
+          "resolve_ruri": false,
+          "auth_enabled": false,
+          "auth_user": "",
+          "auth_password": "",
+          "auth_from_user": "",
+          "auth_from_domain": "",
+          "sst_enabled": true,
+          "sst_min_timer": 600,
+          "sst_max_timer": 900,
+          "sst_accept_501": true,
+          "sip_timer_b": 8000,
+          "dns_srv_failover_timer": 2000,
+          "rtp_ping": false,
+          "rtp_timeout": 30,
+          "force_symmetric_rtp": false,
+          "symmetric_rtp_ignore_rtcp": false,
+          "rerouting_disconnect_code_ids": [],
+          "sst_session_expires": null,
+          "sst_refresh_method_id": 1,
+          "transport_protocol_id": 1,
+          "max_transfers": 0,
+          "max_30x_redirects": 0,
+          "media_encryption_mode": "disabled",
+          "stir_shaken_mode": "disabled",
+          "allowed_rtp_ips": null,
+          "network_protocol_priority": "force_ipv4",
+          "enabled_sip_registration": false,
+          "use_did_in_ruri": false,
+          "diversion_relay_policy": "none",
+          "diversion_inject_mode": "did_number",
+          "cnam_lookup": false,
+          "incoming_auth_username": null,
+          "incoming_auth_password": null
+        }
+      },
+      "created_at": "2015-08-28T06:59:22.805Z"
+    },
+    "relationships": {
+      "voice_in_trunk_group": {
+        "links": {
+          "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/204f6568-a583-40ef-9bef-fff02273b183/relationships/voice_in_trunk_group",
+          "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/204f6568-a583-40ef-9bef-fff02273b183/voice_in_trunk_group"
+        }
+      },
+      "pop": {
+        "links": {
+          "self": "https://sandbox-api.didww.com/v3/voice_in_trunks/204f6568-a583-40ef-9bef-fff02273b183/relationships/pop",
+          "related": "https://sandbox-api.didww.com/v3/voice_in_trunks/204f6568-a583-40ef-9bef-fff02273b183/pop"
+        },
+        "data": {
+          "type": "pops",
+          "id": "b4d3ec87-8b2b-4e91-bcda-da67db8a76ca"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "b4d3ec87-8b2b-4e91-bcda-da67db8a76ca",
+      "type": "pops",
+      "attributes": {
+        "name": "NYC"
+      }
+    }
+  ],
+  "meta": {
+    "api_version": "2026-04-16"
+  }
+}


### PR DESCRIPTION
Implements the four long-standing `xit` placeholders (dating back to 2017–2018) that described "create/update + assign relationship + include in response" but were never written:

- `VoiceInTrunkGroup` POST + assign `voice_in_trunks` + include
- `SharedCapacityGroup` POST + assign `dids` + include
- `VoiceInTrunk` POST + assign `pop` + include
- `VoiceInTrunk` PATCH + assign `pop` + include

### Approach
- Uses `record.request_includes(:rel)` to emit `?include=` on POST/PATCH, then asserts the `included` resources deserialize straight into the associations (no second HTTP request — WebMock would fail otherwise).
- Fixtures captured from the **live sandbox** via `GET …?include=` (authentic JSON:API shape, identical to what POST/PATCH-with-include returns). The one real DID number was normalized to a documentation placeholder; no credentials/IPs/internal hosts present.

### Result
Suite: **532 examples, 0 failures, 0 pending** (was 4 pending). Rubocop clean.