### PR TITLE
fix: clear the master SonarCloud backlog

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,14 +5,11 @@ on:
     branches:
       - master
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         ruby: [ '3.3', '3.4', '4.0' ]
@@ -58,6 +55,11 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/examples/countries.rb
+++ b/examples/countries.rb
@@ -27,7 +27,7 @@ filtered.each do |country|
 end
 
 # Find a specific country
-if !filtered.empty?
+unless filtered.empty?
   puts "\n=== Specific Country ==="
   country = DIDWW::Client.countries.find(filtered.first.id).first
   puts "Found: #{country.name}"

--- a/examples/did_groups.rb
+++ b/examples/did_groups.rb
@@ -37,7 +37,7 @@ did_groups.first(3).each do |did_group|
 end
 
 # Find a specific DID group
-if !did_groups.empty?
+unless did_groups.empty?
   puts "\n=== Specific DID Group ==="
   did_group = DIDWW::Client.did_groups
                .includes(:stock_keeping_units)

--- a/examples/did_reservations.rb
+++ b/examples/did_reservations.rb
@@ -44,7 +44,7 @@ available_dids.first(10).each do |available_did|
 end
 
 # Find a specific reservation if available
-if !reservations.empty?
+unless reservations.empty?
   puts "\n=== Specific Reservation Details ==="
   specific_reservation = DIDWW::Client.did_reservations
                          .find(reservations.first.id)

--- a/examples/exports.rb
+++ b/examples/exports.rb
@@ -60,7 +60,7 @@ else
 end
 
 # Find and inspect a specific export
-if !exports.empty?
+unless exports.empty?
   puts "\n=== Specific Export Details ==="
   specific_export = DIDWW::Client.exports
                     .find(exports.first.id)

--- a/examples/orders_all_item_types.rb
+++ b/examples/orders_all_item_types.rb
@@ -36,7 +36,7 @@ puts "Available DID 2: #{available_did2.number}"
 # Helper to get SKU from available DID
 def get_sku(available_did)
   if available_did.did_group.nil? || available_did.did_group.stock_keeping_units.nil? || available_did.did_group.stock_keeping_units.empty?
-    raise "No stock_keeping_units for available DID #{available_did.id}"
+    raise StandardError, "No stock_keeping_units for available DID #{available_did.id}"
   end
   available_did.did_group.stock_keeping_units.first
 end
@@ -53,14 +53,9 @@ did_groups = DIDWW::Client.did_groups
               .includes(:stock_keeping_units)
               .all
 
-sku_for_qty = nil
-did_groups.each do |dg|
-  if !dg.stock_keeping_units.nil? && !dg.stock_keeping_units.empty?
-    sku_for_qty = dg.stock_keeping_units.first
-    puts "SKU for qty order: #{sku_for_qty.id}"
-    break
-  end
-end
+group_with_skus = did_groups.find { |dg| !dg.stock_keeping_units.nil? && !dg.stock_keeping_units.empty? }
+sku_for_qty = group_with_skus&.stock_keeping_units&.first
+puts "SKU for qty order: #{sku_for_qty.id}" if sku_for_qty
 
 if sku_for_qty.nil?
   puts 'No DID group with stock_keeping_units found'
@@ -72,7 +67,7 @@ puts "\n=== Reserving DID ==="
 reservation = DIDWW::Client.did_reservations.new
 reservation.available_did = available_did2
 
-if !reservation.save
+unless reservation.save
   puts "Error creating reservation: #{reservation.errors.full_messages}"
   exit 1
 end

--- a/examples/regions.rb
+++ b/examples/regions.rb
@@ -35,7 +35,7 @@ regions.first(5).each do |region|
 end
 
 # Fetch a specific region
-if !regions.empty?
+unless regions.empty?
   puts "\n=== Specific Region ==="
   region = DIDWW::Client.regions
             .includes(:country)

--- a/examples/shared_capacity_groups.rb
+++ b/examples/shared_capacity_groups.rb
@@ -36,7 +36,7 @@ capacity_pools = DIDWW::Client.capacity_pools
                   .includes(:shared_capacity_groups)
                   .all
 
-if !capacity_pools.empty?
+unless capacity_pools.empty?
   pool = capacity_pools.first
   puts "Capacity Pool: #{pool.name}"
   if pool.shared_capacity_groups && !pool.shared_capacity_groups.empty?

--- a/examples/voice_in_trunks.rb
+++ b/examples/voice_in_trunks.rb
@@ -33,7 +33,7 @@ trunks.first(10).each do |trunk|
 end
 
 # Find a specific trunk by ID
-if !trunks.empty?
+unless trunks.empty?
   puts "\n=== Specific Trunk Details ==="
   specific_trunk = DIDWW::Client.voice_in_trunks.find(trunks.first.id).first
   puts "Trunk: #{specific_trunk.name}"

--- a/lib/didww/base_middleware.rb
+++ b/lib/didww/base_middleware.rb
@@ -6,9 +6,9 @@ module DIDWW
       request_env[:request_headers].merge!(request_headers(request_env))
       request_env.url.host = URI(DIDWW::Client.api_base_url).host
 
-      @app.call(request_env).on_complete do |response_env|
+      @app.call(request_env).on_complete do |_response_env|
         # do something with the response
-        # response_env[:response_headers].merge!(...)
+        # _response_env[:response_headers].merge!(...)
       end
     end
 

--- a/lib/didww/types/ip_addresses.rb
+++ b/lib/didww/types/ip_addresses.rb
@@ -3,7 +3,7 @@
 module DIDWW
   module Types
     module IpAddresses
-      module_function
+      extend self
 
       def cast(values, default)
         return default unless values.is_a?(Array)

--- a/lib/didww/types/strings.rb
+++ b/lib/didww/types/strings.rb
@@ -3,7 +3,7 @@
 module DIDWW
   module Types
     module Strings
-      module_function
+      extend self
 
       def cast(values, default)
         return default unless values.is_a?(Array)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,6 @@ RSpec.configure do |config|
 end
 
 DIDWW::Client.configure do |client|
-  client.api_key  = ENV['API_KEY']
+  client.api_key  = ENV.fetch('API_KEY', nil)
   client.api_mode = :sandbox
 end


### PR DESCRIPTION
Fixes the master SonarCloud quality gate (was failing on new_duplicated_lines_density): small style fixes (unless vs if!, extend self vs module_function, specific exception class, Enumerable#find vs each+break, ENV.fetch, underscore-prefixed unused param) and moves GitHub Actions permissions from workflow to job level. No behavior changes, all tests pass.

The autoload refactor and spec-file literal-deduplication that were part of an earlier version of this PR moved to #95 and were dropped respectively — neither was required to pass the quality gate.